### PR TITLE
DBD::MariaDB driver was registered into DBI in version 1.640

### DIFF
--- a/lib/DBD/MariaDB.pm
+++ b/lib/DBD/MariaDB.pm
@@ -38,7 +38,8 @@ sub driver{
 				 });
 
     if (!$methods_are_installed) {
-	local $SIG{__WARN__} = sub {}; # disable warning: method name prefix 'mariadb_' is not associated with a registered driver
+	# for older DBI versions disable warning: method name prefix 'mariadb_' is not associated with a registered driver
+	local $SIG{__WARN__} = sub {} unless eval { DBI->VERSION(1.640) };
 	DBD::MariaDB::db->install_method('mariadb_sockfd');
 	DBD::MariaDB::db->install_method('mariadb_async_result');
 	DBD::MariaDB::db->install_method('mariadb_async_ready');


### PR DESCRIPTION
See: https://github.com/perl5-dbi/dbi/pull/56
See: https://www.nntp.perl.org/group/perl.dbi.announce/2018/01/msg497.html