### PR TITLE
Set minimal DBI version and remove useless checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ perl:
 
 matrix:
   include:
+    - perl: "5.8.1"
+      env: DBI_VERSION=1.608
     - perl: "5.22"
       env: DB=MySQL VERSION=4.1.22
     - perl: "5.22"
@@ -279,6 +281,7 @@ before_install:
 
 install:
   - perlbrew install-cpanm --force --notest
+  - if [ -n "$DBI_VERSION" ]; then cpanm --quiet --notest DBI@$DBI_VERSION; fi
   - cpanm --quiet --notest --skip-satisfied DBI Devel::CheckLib
   - cpanm --quiet --notest --skip-satisfied --installdeps --with-configure --with-develop --with-recommends --with-suggests .
   - if [ -n "$DB" ]; then

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -395,7 +395,7 @@ if (eval $ExtUtils::MakeMaker::VERSION >= 5.43) {
   $o{'AUTHOR'} = 'Patrick Galbraith <patg@patg.net>';
   $o{'ABSTRACT'} =
     'MariaDB and MySQL driver for the Perl5 Database Interface (DBI)';
-  $o{'PREREQ_PM'} = { 'DBI' => 1.609 };
+  $o{'PREREQ_PM'} = { 'DBI' => 1.608 };
   %o=(%o,
     LICENSE => 'perl',
     MIN_PERL_VERSION => '5.008001',
@@ -494,7 +494,7 @@ if (eval $ExtUtils::MakeMaker::VERSION >= 5.43) {
                        'Test::Deep'   => 0,
                        'Time::HiRes'  => 0,
     },
-    CONFIGURE_REQUIRES => { 'DBI' => '1.609',
+    CONFIGURE_REQUIRES => { 'DBI' => '1.608',
                             'Data::Dumper' => 0,
                             'Devel::CheckLib' => '1.09',
                             'ExtUtils::MakeMaker' => 0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -259,7 +259,6 @@ if ($^O eq 'VMS') {
   $cflags = "\$(DBI_INSTARCH_DIR),$opt->{'cflags'}";
 }
 $cflags .= " -DDBD_MYSQL_WITH_SSL" if !$opt->{'nossl'};
-$cflags .= " -DDBD_MYSQL_INSERT_ID_IS_GOOD" if $DBI::VERSION > 1.42;
 $cflags .= " -DDBD_MYSQL_NO_CLIENT_FOUND_ROWS" if $opt->{'nofoundrows'};
 $cflags .= " -g ";
 my %o = ( 'NAME' => 'DBD::MariaDB',

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -6164,7 +6164,6 @@ SV* mariadb_db_quote(SV *dbh, SV *str, SV *type)
   return result;
 }
 
-#ifdef DBD_MYSQL_INSERT_ID_IS_GOOD
 SV *mariadb_db_last_insert_id(SV *dbh, imp_dbh_t *imp_dbh,
         SV *catalog, SV *schema, SV *table, SV *field, SV *attr)
 {
@@ -6181,7 +6180,6 @@ SV *mariadb_db_last_insert_id(SV *dbh, imp_dbh_t *imp_dbh,
   ASYNC_CHECK_RETURN(dbh, &PL_sv_undef);
   return sv_2mortal(my_ulonglong2sv(aTHX_ mysql_insert_id(imp_dbh->pmysql)));
 }
-#endif
 
 int mariadb_db_async_result(SV* h, MYSQL_RES** resp)
 {

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -396,6 +396,7 @@ struct imp_sth_st {
  *
  * These defines avoid name clashes for multiple statically linked DBD's	*/
 #define dbd_init		mariadb_dr_init
+#define dbd_discon_all		mariadb_dr_discon_all
 #define dbd_db_login6_sv	mariadb_db_login6_sv
 #define dbd_db_commit		mariadb_db_commit
 #define dbd_db_rollback		mariadb_db_rollback
@@ -403,6 +404,7 @@ struct imp_sth_st {
 #define dbd_db_destroy		mariadb_db_destroy
 #define dbd_db_STORE_attrib	mariadb_db_STORE_attrib
 #define dbd_db_FETCH_attrib	mariadb_db_FETCH_attrib
+#define dbd_db_last_insert_id   mariadb_db_last_insert_id
 #define dbd_st_prepare_sv	mariadb_st_prepare_sv
 #define dbd_st_execute		mariadb_st_execute
 #define dbd_st_fetch		mariadb_st_fetch
@@ -412,11 +414,6 @@ struct imp_sth_st {
 #define dbd_st_STORE_attrib	mariadb_st_STORE_attrib
 #define dbd_st_FETCH_attrib	mariadb_st_FETCH_attrib
 #define dbd_bind_ph		mariadb_st_bind_ph
-#define dbd_discon_all		mariadb_dr_discon_all
-
-#ifdef DBD_MYSQL_INSERT_ID_IS_GOOD /* prototype was broken in some versions of dbi */
-#define dbd_db_last_insert_id   mariadb_db_last_insert_id
-#endif
 
 #include <dbd_xsh.h>
 

--- a/lib/DBD/MariaDB.pm
+++ b/lib/DBD/MariaDB.pm
@@ -142,11 +142,8 @@ sub connect {
 				    ['database', 'host', 'port']);
 
 
-    if ($DBI::VERSION >= 1.49)
-    {
       $dbi_imp_data = delete $attrhash->{dbi_imp_data};
       $connect_ref->{'dbi_imp_data'} = $dbi_imp_data;
-    }
 
     if (!defined($this = DBI::_new_dbh($drh,
             $connect_ref,

--- a/t/70takeimp.t
+++ b/t/70takeimp.t
@@ -15,12 +15,6 @@ my $drh = eval { DBI->install_driver('MariaDB') } or do {
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
 
-unless ($DBI::VERSION ge '1.607') {
-    plan skip_all => "version of DBI $DBI::VERSION doesn't support this test. Can't continue test";
-}
-unless ($dbh->can('take_imp_data')) {
-    plan skip_all => "version of DBI $DBI::VERSION doesn't support this test. Can't continue test";
-}
 plan tests => 21;
 
 pass("obtained driver handle");

--- a/t/71impdata.t
+++ b/t/71impdata.t
@@ -20,12 +20,6 @@ if (! defined $drh) {
     plan skip_all => "Can't obtain driver handle. Can't continue test";
 }
 
-unless ($DBI::VERSION ge '1.607') {
-    plan skip_all => "version of DBI $DBI::VERSION doesn't support this test. Can't continue test";
-}
-unless ($dbh->can('take_imp_data')) {
-    plan skip_all => "version of DBI $DBI::VERSION doesn't support this test. Can't continue test";
-}
 plan tests => 10;
 
 pass("Connected to database");

--- a/t/89async-method-check.t
+++ b/t/89async-method-check.t
@@ -11,8 +11,11 @@ require 'lib.pl';
 
 my @common_safe_methods = qw/
 can                    err   errstr    parse_trace_flag    parse_trace_flags
-private_attribute_info trace trace_msg visit_child_handles
+private_attribute_info trace trace_msg
 /;
+
+# Not all DBI versions support method visit_child_handles
+push @common_safe_methods, 'visit_child_handles' if DBI::db->can("visit_child_handles");
 
 my @db_safe_methods   = (@common_safe_methods, qw/
 clone mariadb_async_ready


### PR DESCRIPTION
DBD::MariaDB already uses API of 1.608 version, therefore this is correct
minimal required version. Minimal required Perl version is 5.8.1.

Remove also checks for DBI version 1.42 and 1.607.
Those checks are not needed anymore as minimal required version is 1.608.