### PR TITLE
Distinguish between NULL and "" and hide passwords in trace logs

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2519,17 +2519,15 @@ MYSQL *mariadb_dr_connect(
 */
 static char *safe_hv_fetch(pTHX_ HV *hv, const char *name, int name_length)
 {
-  SV** svp;
-  STRLEN len;
-  char *res= NULL;
+  SV** svp = hv_fetch(hv, name, name_length, FALSE);
+  if (!svp || !*svp)
+    return NULL;
 
-  if ((svp= hv_fetch(hv, name, name_length, FALSE)))
-  {
-    res= SvPV(*svp, len);
-    if (!len)
-      res= NULL;
-  }
-  return res;
+  SvGETMAGIC(*svp);
+  if (!SvOK(*svp))
+    return NULL;
+
+  return SvPV_nolen(*svp);
 }
 
 /*

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1796,7 +1796,7 @@ MYSQL *mariadb_dr_connect(
 		  " uid = %s, pwd = %s\n",
 		  host ? host : "NULL", portNr,
 		  user ? user : "NULL",
-		  password ? password : "NULL");
+		  !password ? "NULL" : !password[0] ? "" : "****");
 
   {
 
@@ -2587,7 +2587,7 @@ static int mariadb_db_my_login(pTHX_ SV* dbh, imp_dbh_t *imp_dbh)
 		  "host = %s, port = %s\n",
 		  dbname ? dbname : "NULL",
 		  user ? user : "NULL",
-		  password ? password : "NULL",
+		  !password ? "NULL" : !password[0] ? "" : "****",
 		  host ? host : "NULL",
 		  port ? port : "NULL");
 
@@ -2638,7 +2638,7 @@ int mariadb_db_login6_sv(SV *dbh, imp_dbh_t *imp_dbh, SV *dsn, SV *user, SV *pas
 		  "imp_dbh->connect: dsn = %s, uid = %s, pwd = %s\n",
                   SvOK(dsn) ? neatsvpv(dsn, 0) : "NULL",
                   SvOK(user) ? neatsvpv(user, 0) : "NULL",
-                  SvOK(password) ? neatsvpv(password, 0) : "NULL");
+                  !SvOK(password) ? "NULL" : !(SvPV_nolen(password))[0] ? "''" : "****");
 
   imp_dbh->stats.auto_reconnects_ok= 0;
   imp_dbh->stats.auto_reconnects_failed= 0;


### PR DESCRIPTION
Some arguments (host, user, passwd, db, port or unix_socket) passed to
mysql_real_connect() have different meaning when are NULL and when are "".
But DBD::MariaDB currently converts everything to nul term strings which
disallow usage of NULL arguments.

This commit fixes it by mapping Perl's undef to C's NULL and Perl's empty
string to C's "".

Also hide passwords in trace logs.

See: https://dev.mysql.com/doc/refman/en/mysql-real-connect.html
See: https://mariadb.com/kb/en/library/mysql_real_connect/

Fixes: https://github.com/perl5-dbi/DBD-mysql/issues/167
Fixes: https://rt.cpan.org/Public/Bug/Display.html?id=108650