### PR TITLE
Allow to run tests in parallel via make test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -368,7 +368,7 @@ before_script:
     elif [ -n "$DB" ]; then
       export DBD_MARIADB_CONFIG="$SANDBOX_HOME/msb/my sql_config" ;
     fi
-  - export HARNESS_OPTIONS=j1
+  - export HARNESS_OPTIONS=j4
   - export RELEASE_TESTING=1
   - export CONNECTION_TESTING=1
   - export SKIP_CRASH_TESTING=1

--- a/MANIFEST
+++ b/MANIFEST
@@ -14,6 +14,7 @@ myld
 MariaDB.xs
 README.pod
 socket.c
+testrules.yml
 t/00base.t
 t/05dbcreate.t
 t/10connect.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -461,6 +461,7 @@ if (eval $ExtUtils::MakeMaker::VERSION >= 5.43) {
       prereqs => {
         test => {
           recommends => {
+            'TAP::Harness' => '3.31',
             'Proc::ProcessTable' => 0,
           },
           suggests => {

--- a/t/40types.t
+++ b/t/40types.t
@@ -20,54 +20,54 @@ plan tests => 39*2;
 for my $mariadb_server_prepare (0, 1) {
 $dbh->{mariadb_server_prepare} = $mariadb_server_prepare;
 
-ok($dbh->do(qq{DROP TABLE IF EXISTS t1}), "making slate clean");
+ok($dbh->do(qq{DROP TABLE IF EXISTS t_dbd_40types}), "making slate clean");
 
-ok($dbh->do(qq{CREATE TABLE t1 (num INT)}), "creating table");
-ok($dbh->do(qq{INSERT INTO t1 VALUES (100)}), "loading data");
+ok($dbh->do(qq{CREATE TABLE t_dbd_40types (num INT)}), "creating table");
+ok($dbh->do(qq{INSERT INTO t_dbd_40types VALUES (100)}), "loading data");
 
-my ($val) = $dbh->selectrow_array("SELECT * FROM t1");
+my ($val) = $dbh->selectrow_array("SELECT * FROM t_dbd_40types");
 is($val, 100);
 
 my $sv = svref_2object(\$val);
 ok($sv->FLAGS & SVf_IOK, "scalar is integer");
 ok(!($sv->FLAGS & (SVf_IVisUV|SVf_NOK|SVf_POK)), "scalar is not unsigned intger or double or string");
 
-ok($dbh->do(qq{DROP TABLE t1}), "cleaning up");
+ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 
-ok($dbh->do(qq{CREATE TABLE t1 (num VARCHAR(10))}), "creating table");
-ok($dbh->do(qq{INSERT INTO t1 VALUES ('string')}), "loading data");
+ok($dbh->do(qq{CREATE TABLE t_dbd_40types (num VARCHAR(10))}), "creating table");
+ok($dbh->do(qq{INSERT INTO t_dbd_40types VALUES ('string')}), "loading data");
 
-($val) = $dbh->selectrow_array("SELECT * FROM t1");
+($val) = $dbh->selectrow_array("SELECT * FROM t_dbd_40types");
 is($val, "string");
 
 $sv = svref_2object(\$val);
 ok($sv->FLAGS & SVf_POK, "scalar is string");
 ok(!($sv->FLAGS & (SVf_IOK|SVf_NOK)), "scalar is not intger or double");
 
-ok($dbh->do(qq{DROP TABLE t1}), "cleaning up");
+ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 
 SKIP: {
 skip "New Data types not supported by server", 26
 if !MinimumVersion($dbh, '5.0');
 
-ok($dbh->do(qq{CREATE TABLE t1 (d DECIMAL(5,2))}), "creating table");
+ok($dbh->do(qq{CREATE TABLE t_dbd_40types (d DECIMAL(5,2))}), "creating table");
 
-my $sth= $dbh->prepare("SELECT * FROM t1 WHERE 1 = 0");
+my $sth= $dbh->prepare("SELECT * FROM t_dbd_40types WHERE 1 = 0");
 ok($sth->execute(), "getting table information");
 
 is_deeply($sth->{TYPE}, [ 3 ], "checking column type");
 
 ok($sth->finish);
 
-ok($dbh->do(qq{DROP TABLE t1}), "cleaning up");
+ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 
 #
 # Bug #23936: bind_param() doesn't work with SQL_DOUBLE datatype
 # Bug #24256: Another failure in bind_param() with SQL_DOUBLE datatype
 #
-ok($dbh->do(qq{CREATE TABLE t1 (num DOUBLE)}), "creating table");
+ok($dbh->do(qq{CREATE TABLE t_dbd_40types (num DOUBLE)}), "creating table");
 
-$sth= $dbh->prepare("INSERT INTO t1 VALUES (?)");
+$sth= $dbh->prepare("INSERT INTO t_dbd_40types VALUES (?)");
 ok($sth->bind_param(1, 2.1, DBI::SQL_DOUBLE), "binding parameter");
 ok($sth->execute(), "inserting data");
 ok($sth->finish);
@@ -75,7 +75,7 @@ ok($sth->bind_param(1, -1, DBI::SQL_DOUBLE), "binding parameter");
 ok($sth->execute(), "inserting data");
 ok($sth->finish);
 
-my $ret = $dbh->selectall_arrayref("SELECT * FROM t1");
+my $ret = $dbh->selectall_arrayref("SELECT * FROM t_dbd_40types");
 cmp_deeply($ret, [ [num(2.1, 0.00001)], [num(-1, 0.00001)] ]);
 
 $sv = svref_2object(\$ret->[0]->[0]);
@@ -86,15 +86,15 @@ $sv = svref_2object(\$ret->[1]->[0]);
 ok($sv->FLAGS & SVf_NOK, "scalar is double");
 ok(!($sv->FLAGS & (SVf_IOK|SVf_POK)), "scalar is not integer or string");
 
-ok($dbh->do(qq{DROP TABLE t1}), "cleaning up");
+ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 
 #
 # [rt.cpan.org #19212] Mysql Unsigned Integer Fields
 #
-ok($dbh->do(qq{CREATE TABLE t1 (num INT UNSIGNED)}), "creating table");
-ok($dbh->do(qq{INSERT INTO t1 VALUES (0),(4294967295)}), "loading data");
+ok($dbh->do(qq{CREATE TABLE t_dbd_40types (num INT UNSIGNED)}), "creating table");
+ok($dbh->do(qq{INSERT INTO t_dbd_40types VALUES (0),(4294967295)}), "loading data");
 
-$ret = $dbh->selectall_arrayref("SELECT * FROM t1");
+$ret = $dbh->selectall_arrayref("SELECT * FROM t_dbd_40types");
 is_deeply($ret, [ [0],  [4294967295] ]);
 
 $sv = svref_2object(\$ret->[0]->[0]);
@@ -105,7 +105,7 @@ $sv = svref_2object(\$ret->[1]->[0]);
 ok($sv->FLAGS & (SVf_IOK|SVf_IVisUV), "scalar is unsigned integer");
 ok(!($sv->FLAGS & (SVf_NOK|SVf_POK)), "scalar is not double or string");
 
-ok($dbh->do(qq{DROP TABLE t1}), "cleaning up");
+ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 };
 
 }

--- a/t/80procs.t
+++ b/t/80procs.t
@@ -69,10 +69,10 @@ ok $sth->finish;
 
 ok $dbh->do("DROP PROCEDURE dbd_mysql_t80testproc");
 
-ok $dbh->do("drop procedure if exists test_multi_sets");
+ok $dbh->do("drop procedure if exists test_multi_sets_t80");
 
 $proc_create = <<EOT;
-        create procedure test_multi_sets ()
+        create procedure test_multi_sets_t80 ()
         deterministic
         begin
         select user() as first_col;
@@ -83,7 +83,7 @@ EOT
 
 ok $dbh->do($proc_create);
 
-ok ($sth = $dbh->prepare("call test_multi_sets()"));
+ok ($sth = $dbh->prepare("call test_multi_sets_t80()"));
 
 ok $sth->execute();
 

--- a/t/81procs.t
+++ b/t/81procs.t
@@ -34,13 +34,13 @@ ok ($dbh = DBI->connect($test_dsn, $test_user, $test_password,
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t81procs");
 
-my $drop_proc= "DROP PROCEDURE IF EXISTS testproc";
+my $drop_proc= "DROP PROCEDURE IF EXISTS dbd_mysql_t81testproc";
 
 ok $dbh->do($drop_proc);
 
 
 my $proc_create = <<EOPROC;
-create procedure testproc() deterministic
+create procedure dbd_mysql_t81testproc() deterministic
   begin
     declare a,b,c,d int;
     set a=1;
@@ -56,7 +56,7 @@ EOPROC
 
 ok $dbh->do($proc_create);
 
-my $proc_call = 'CALL testproc()';
+my $proc_call = 'CALL dbd_mysql_t81testproc()';
 
 ok $dbh->do($proc_call);
 
@@ -67,12 +67,12 @@ ok $sth->execute();
 
 ok $sth->finish;
 
-ok $dbh->do("DROP PROCEDURE testproc");
+ok $dbh->do("DROP PROCEDURE dbd_mysql_t81testproc");
 
-ok $dbh->do("drop procedure if exists test_multi_sets");
+ok $dbh->do("drop procedure if exists test_multi_sets_t81");
 
 $proc_create = <<EOT;
-        create procedure test_multi_sets ()
+        create procedure test_multi_sets_t81 ()
         deterministic
         begin
         select user() as first_col;
@@ -83,7 +83,7 @@ EOT
 
 ok $dbh->do($proc_create);
 
-ok ($sth = $dbh->prepare("call test_multi_sets()"));
+ok ($sth = $dbh->prepare("call test_multi_sets_t81()"));
 
 ok $sth->execute();
 

--- a/t/lib.pl
+++ b/t/lib.pl
@@ -58,7 +58,7 @@ sub DbiTestConnect {
         my $err;
         if ( $@ ) {
             $err = $@;
-            $err =~ s/ at \S+ line \d+\s*$//;
+            $err =~ s/ at \S+ line \d+\.?\s*$//;
         }
         if ( not $err ) {
             $err = $DBI::errstr;
@@ -68,6 +68,8 @@ sub DbiTestConnect {
             $dsn =~ s/^DBI:[^:]+://;
             $err = "DBI connect('$dsn','$user',...) failed: $err";
         }
+        my ($func, $file, $line) = caller;
+        $err .= " at $file line $line.";
         if ( $ENV{CONNECTION_TESTING} ) {
             BAIL_OUT "no database connection: $err";
         } else {

--- a/testrules.yml
+++ b/testrules.yml
@@ -1,0 +1,5 @@
+seq:
+  - seq: t/00base.t
+  - seq: t/05dbcreate.t
+  - seq: t/10connect.t
+  - par: **

--- a/testrules.yml
+++ b/testrules.yml
@@ -2,4 +2,9 @@ seq:
   - seq: t/00base.t
   - seq: t/05dbcreate.t
   - seq: t/10connect.t
-  - par: **
+  - par:
+    - seq: t/60leaks.t
+    - seq: t/87async.t
+    - seq: t/rt75353-innodb-lock-timeout.t
+    - seq: t/rt85919-fetch-lost-connection.t
+    - par: **


### PR DESCRIPTION
Use testrules.yml definition file for TAP::Harness which is used by prove
and also by ExtUtils::MakeMaker's make test. All tests except those which
initialize database can be run in parallel and in any order.