### PR TITLE
Check that correct number of bind parameters were supplied

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -919,6 +919,8 @@ static void bind_param(imp_sth_ph_t *ph, SV *value, IV sql_type)
     ph->value = NULL;
   }
 
+  ph->bound = TRUE;
+
   if (sql_type)
     ph->type = sql_type;
 
@@ -4442,6 +4444,15 @@ int mariadb_st_execute(SV* sth, imp_sth_t* imp_sth)
 
   if (!SvROK(sth)  ||  SvTYPE(SvRV(sth)) != SVt_PVHV)
     croak("Expected hash array");
+
+  for (i = 0; i < DBIc_NUM_PARAMS(imp_sth); ++i)
+  {
+    if (!imp_sth->params[i].bound)
+    {
+      mariadb_dr_do_error(sth, ER_WRONG_ARGUMENTS, "Wrong number of bind parameters", "HY000");
+      return -2;
+    }
+  }
 
   /* Free cached array attributes */
   for (i= 0;  i < AV_ATTRIB_LAST;  i++)

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -344,6 +344,7 @@ typedef struct imp_sth_ph_st {
     char* value;
     STRLEN len;
     int type;
+    bool bound;
 } imp_sth_ph_t;
 
 /*

--- a/t/40bindparam2.t
+++ b/t/40bindparam2.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
   { RaiseError => 1, AutoCommit => 1});
 
-plan tests => 13;
+plan tests => 14;
 
 SKIP: {
     skip 'SET @@auto_increment_offset needs MySQL >= 5.0.2', 2 unless $dbh->{mariadb_serverversion} >= 50002;
@@ -34,6 +34,8 @@ ok ($rows= $dbh->selectall_arrayref("SELECT * FROM dbd_mysql_t40bindparam2"));
 is $rows->[0][1], 1, "\$rows->[0][1] == 1";
 
 ok (my $sth = $dbh->prepare("UPDATE dbd_mysql_t40bindparam2 SET num = ? WHERE id = ?"));
+
+ok ($sth->bind_param(1, undef));
 
 ok ($sth->bind_param(2, 1, SQL_INTEGER()));
 

--- a/t/40server_prepare_crash.t
+++ b/t/40server_prepare_crash.t
@@ -39,7 +39,7 @@ ok $sth->execute();
 ok $sth->finish();
 
 ok $sth = $dbh->prepare("SELECT * FROM t WHERE i=? AND n=?");
-ok $sth->execute();
+ok $sth->execute(1, 1);
 ok $sth->finish();
 
 ok $sth = $dbh->prepare("SELECT 1 FROM t WHERE i = ?" . (" OR i = ?" x 10000));

--- a/t/55utf8.t
+++ b/t/55utf8.t
@@ -18,7 +18,7 @@ if ($dbh->{mariadb_serverversion} < 50000) {
     plan skip_all =>
         "SKIP TEST: You must have MySQL version 5.0 and greater for this test to run";
 }
-plan tests => 44 * 2;
+plan tests => 42 * 2;
 
 for my $mariadb_server_prepare (0, 1) {
 $dbh= DBI->connect("$test_dsn;mariadb_server_prepare=$mariadb_server_prepare;mariadb_server_prepare_disable_fallback=1", $test_user, $test_password,
@@ -123,8 +123,6 @@ cmp_ok $ref->[7], 'eq', $latin1_str2, 'latin1 data are returned as latin1 when N
 ok $sth = $dbh->prepare("SELECT 1 FROM dbd_mysql_t55utf8 WHERE bincol = ?");
 ok !defined eval { $sth->bind_param(1, $unicode_str, DBI::SQL_BINARY) };
 like $@, qr/^Wide character in /, '';
-ok $sth->execute();
-ok $sth->finish();
 
 ok $dbh->do("DROP TABLE dbd_mysql_t55utf8");
 

--- a/t/rt83494-quotes-comments.t
+++ b/t/rt83494-quotes-comments.t
@@ -20,13 +20,19 @@ my %tests = (
   quote        => " -- 'Tis the quote that confuses DBI::MySQL\nSELECT ?"
 );
 
+for my $mariadb_server_prepare (0, 1) {
+
+$dbh->{mariadb_server_prepare} = $mariadb_server_prepare;
+
 for my $test ( sort keys %tests ) {
 
   my $sth = $dbh->prepare($tests{$test});
   ok($sth, 'created statement hande');
-  ok($sth->execute(), 'executing');
+  ok($sth->execute(42), 'executing');
   ok($sth->{ParamValues}, 'values');
   ok($sth->finish(), 'finish');
+
+}
 
 }
 


### PR DESCRIPTION
DBI checks number of parameters when they are passed via execute() method,
not via bind_param(). Therefore DBD::MariaDB driver needs to check for
number of bind parameters in other cases.

Prior this change, DBD::MariaDB passed empty allocated memory for every
parameter which was not correctly bound.