### PR TITLE
Fix retrieving $sth attributes after $sth->fetchall* call

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -42,6 +42,7 @@ t/40numrows.t
 t/40server_prepare.t
 t/40server_prepare_crash.t
 t/40server_prepare_error.t
+t/40sth_attr.t
 t/40types.t
 t/41bindparam.t
 t/41blobs_prepare.t

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4756,7 +4756,6 @@ mariadb_st_fetch(SV *sth, imp_sth_t* imp_sth)
   int av_length, av_readonly;
   MYSQL_ROW cols;
   D_imp_dbh_from_sth;
-  MYSQL* svsock= imp_dbh->pmysql;
   imp_sth_fbh_t *fbh;
   D_imp_xxh(sth);
 #if MYSQL_VERSION_ID >=SERVER_PREPARE_VERSION
@@ -4848,8 +4847,6 @@ mariadb_st_fetch(SV *sth, imp_sth_t* imp_sth)
                  mysql_stmt_error(imp_sth->stmt),
                  mysql_stmt_sqlstate(imp_sth->stmt));
       }
-
-      mariadb_st_finish(sth, imp_sth);
 
       return Nullav;
     }
@@ -5094,12 +5091,6 @@ process:
         mariadb_dr_do_error(sth, mysql_errno(imp_dbh->pmysql),
                  mysql_error(imp_dbh->pmysql),
                  mysql_sqlstate(imp_dbh->pmysql));
-
-
-#if MYSQL_VERSION_ID >= MULTIPLE_RESULT_SET_VERSION
-      if (!mysql_more_results(svsock))
-#endif
-        mariadb_st_finish(sth, imp_sth);
       return Nullav;
     }
 

--- a/t/25lockunlock.t
+++ b/t/25lockunlock.t
@@ -43,6 +43,7 @@ my ($row, $errstr);
 $errstr= '';
 $row = $sth->fetchrow_arrayref;
 $errstr= $sth->errstr;
+$sth->finish;
 ok !defined($row), "Fetch should have failed";
 ok !defined($errstr), "Fetch should have failed";
 

--- a/t/35prepare.t
+++ b/t/35prepare.t
@@ -13,7 +13,7 @@ use vars qw($test_dsn $test_user $test_password);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
     { RaiseError => 1, AutoCommit => 1});
 
-plan tests => 49;
+plan tests => 50;
 
 ok(defined $dbh, "Connected to database");
 
@@ -94,6 +94,7 @@ ok($sth= $dbh->prepare("SELECT 1"), "Prepare - Testing bug #20153");
 ok($sth->execute(), "Execute - Testing bug #20153");
 ok($sth->fetchrow_arrayref(), "Fetch - Testing bug #20153");
 ok(!($sth->fetchrow_arrayref()),"Not Fetch - Testing bug #20153");
+ok($sth->finish);
 
 # Install a handler so that a warning about unfreed resources gets caught
 $SIG{__WARN__} = sub { die @_ };

--- a/t/40numrows.t
+++ b/t/40numrows.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 my ($dbh, $sth, $aref);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
-plan tests => 30;
+plan tests => 31;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t40numrows");
 
@@ -74,6 +74,8 @@ is $sth->rows, 3, 'rows should be 3';
 ok ($aref= $sth->fetchall_arrayref);
 
 is scalar @$aref, 3, 'Verified rows should be 3';
+
+ok $sth->finish;
 
 ok $dbh->do("DROP TABLE dbd_mysql_t40numrows"), "drop table dbd_mysql_t40numrows";
 

--- a/t/40sth_attr.t
+++ b/t/40sth_attr.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require "lib.pl";
+
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1 });
+
+plan tests => 11;
+
+ok($dbh->do("CREATE TEMPORARY TABLE t(id INT)"));
+ok($dbh->do("INSERT INTO t(id) VALUES(1)"));
+
+my $sth = $dbh->prepare("SELECT * FROM t");
+ok($sth->execute());
+ok($sth->fetchall_arrayref());
+is_deeply($sth->{NAME}, ["id"]);
+ok($sth->finish());
+
+my $sth2 = $dbh->prepare("SELECT * FROM t", { mariadb_server_prepare => 1 });
+ok($sth2->execute());
+ok($sth2->fetchall_arrayref());
+is_deeply($sth2->{NAME}, ["id"]);
+ok($sth2->finish());
+
+ok($dbh->disconnect());

--- a/t/56connattr.t
+++ b/t/56connattr.t
@@ -36,6 +36,7 @@ if ($@) {
   plan skip_all => "no permission on performance_schema tables";
 }
 
+$dbh->disconnect();
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1,
                         PrintError => 0,


### PR DESCRIPTION
Retrieving $sth attributes after $sth->fetchall* call was not possible. DBI
just threw following error:

DBD::MariaDB::st FETCH failed: statement contains no result

This change fixes problem by letting $sth handle active even after last row
was fetched. When $sth is not active then fetching $sth attributes is not
possible.