### PR TITLE
Skip tests t/80procs.t and t/81procs.t when table mysql.proc doesn't exist

### DIFF
--- a/t/80procs.t
+++ b/t/80procs.t
@@ -22,7 +22,7 @@ if ($dbh->{mariadb_serverversion} < 50000) {
 
 if (!CheckRoutinePerms($dbh)) {
     plan skip_all =>
-        "Your test user does not have ALTER_ROUTINE privileges.";
+        $dbh->errstr();
 }
 
 plan tests => 31;

--- a/t/81procs.t
+++ b/t/81procs.t
@@ -22,7 +22,7 @@ if ($dbh->{mariadb_serverversion} < 50000) {
 
 if (!CheckRoutinePerms($dbh)) {
     plan skip_all =>
-        "Your test user does not have ALTER_ROUTINE privileges.";
+        $dbh->errstr();
 }
 
 plan tests => 32;

--- a/t/lib.pl
+++ b/t/lib.pl
@@ -117,7 +117,7 @@ Check if the current user of the DBH has permissions to create/drop procedures
 
     if (!CheckRoutinePerms($dbh)) {
         plan skip_all =>
-            "Your test user does not have ALTER_ROUTINE privileges.";
+            $dbh->errstr();
     }
 
 =cut
@@ -128,7 +128,8 @@ sub CheckRoutinePerms {
     # check for necessary privs
     local $dbh->{PrintError} = 0;
     if (not eval { $dbh->do('DROP PROCEDURE IF EXISTS testproc') }) {
-        return if $@ =~ qr/alter routine command denied to user/;
+        return 0 if $dbh->errstr() =~ /alter routine command denied to user/;
+        return 0 if $dbh->errstr() =~ /Table 'mysql\.proc' doesn't exist/;
     }
 
     return 1;


### PR DESCRIPTION
PROCEDURE statements do not work without this table so affected tests will
fail with error:

DBD::MariaDB::db do failed: Table 'mysql.proc' doesn't exist at t/80procs.t line 39.
DBD::MariaDB::db do failed: Table 'mysql.proc' doesn't exist at t/81procs.t line 39.