### PR TITLE
Remove usage of $@ in tests where possible

### DIFF
--- a/lib/DBD/MariaDB.pm
+++ b/lib/DBD/MariaDB.pm
@@ -863,9 +863,8 @@ DBD::MariaDB - MariaDB and MySQL driver for the Perl5 Database Interface (DBI)
   # Thus we put an eval around it.
   eval {
       $dbh->do("DROP TABLE foo");
-      1;
   } or do {
-      print "Dropping foo failed: $@\n";
+      print "Dropping foo failed: " . $dbh->errstr() . "\n";
   };
 
   # Create a new table 'foo'. This must not fail, thus we don't

--- a/t/05dbcreate.t
+++ b/t/05dbcreate.t
@@ -15,9 +15,12 @@ $test_dsn_without_db =~ s/^(DBI:[^:]+):(?:[^:;]+)([:;]?)/$1:$2/;
 
 sub fatal_error {
     my ($message) = @_;
-    my $err = $@;
-    $err =~ s/ at \S+ line \d+\.?\s*$//;
-    $err = "unknown error" unless $err;
+    my $err = $DBI::errstr;
+    if (not $err) {
+      $err = $@;
+      $err =~ s/ at \S+ line \d+\.?\s*$//;
+      $err = "unknown error" unless $err;
+    }
     if ( $ENV{CONNECTION_TESTING} ) {
         BAIL_OUT "$message: $err";
     } else {

--- a/t/41int_min_max.t
+++ b/t/41int_min_max.t
@@ -73,7 +73,7 @@ sub test_int_type ($$$$) {
     if ($mode eq 'strict') {
         local $store->{PrintError} = 0;
         ok !defined eval{$store->execute()};
-        like($@, qr/Out of range value (?:adjusted )?for column 'val'/)
+        like($store->errstr(), qr/Out of range value (?:adjusted )?for column 'val'/)
         or note("Error, you stored ".($min-1)." into $mariadb_type, mode=$mode\n".
             Data::Dumper->Dump([$dbh->selectall_arrayref("SELECT * FROM $table")]).
             Data::Dumper->Dump([$dbh->selectall_arrayref("describe $table")])
@@ -95,7 +95,7 @@ sub test_int_type ($$$$) {
     if ($mode eq 'strict') {
         local $store->{PrintError} = 0;
         ok !defined eval{$store->execute()};
-        like($@, qr/Out of range value (?:adjusted )?for column 'val'/)
+        like($store->errstr(), qr/Out of range value (?:adjusted )?for column 'val'/)
         or note("Error, you stored ".($max+1)." into $mariadb_type, mode=$mode\n".
             Data::Dumper->Dump([$dbh->selectall_arrayref("SELECT * FROM $table")]).
             Data::Dumper->Dump([$dbh->selectall_arrayref("describe $table")])

--- a/t/55utf8_jp.t
+++ b/t/55utf8_jp.t
@@ -21,7 +21,7 @@ eval {
   plan skip_all => "Server lc_messages ja_JP are needed for this test";
 };
 
-plan tests => 21;
+plan tests => 22;
 
 my $jpnTable = "\N{U+8868}"; # Japanese table
 my $jpnGender = "\N{U+6027}\N{U+5225}"; # Japanese word "gender"
@@ -93,6 +93,7 @@ eval {
 $SIG{__WARN__} = 'default';
 
 ok($failed);
+like($dieerr, $jpnErr);
 like($DBI::errstr, $jpnErr);
 like($dbh->errstr, $jpnErr);
 

--- a/t/90utf8_params.t
+++ b/t/90utf8_params.t
@@ -39,7 +39,7 @@ foreach my $server_prepare (0, 1) {
     my $enable_str = "mariadb_server_prepare=$server_prepare";
     my $enable_hash = { mariadb_server_prepare => $server_prepare, mariadb_server_prepare_disable_fallback => 1 };
 
-    $dbh = DBI->connect($test_dsn, $test_user, $test_password, $enable_hash) or die DBI->errstr;
+    $dbh = DBI->connect($test_dsn, $test_user, $test_password, $enable_hash);
 
     foreach my $charset ("latin1", "utf8") {
 

--- a/t/rt61849-bind-param-buffer-overflow.t
+++ b/t/rt61849-bind-param-buffer-overflow.t
@@ -15,5 +15,5 @@ my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 
 plan tests => 3;
 my $sth = $dbh->prepare("select * from unknown_table where id=?");
 ok !defined eval { $sth->bind_param(1, $INSECURE_VALUE_FROM_USER, 3) };
-like $@, qr/Binding non-numeric field 1, value '\Q$INSECURE_VALUE_FROM_USER\E' as a numeric!/, "bind_param failed on incorrect numeric value";
+like $sth->errstr(), qr/Binding non-numeric field 1, value '\Q$INSECURE_VALUE_FROM_USER\E' as a numeric!/, "bind_param failed on incorrect numeric value";
 pass "perl interpreter did not crash";

--- a/t/rt75353-innodb-lock-timeout.t
+++ b/t/rt75353-innodb-lock-timeout.t
@@ -58,12 +58,9 @@ ok $dbh1->do("INSERT INTO dbd_mysql_rt75353_innodb_lock_timeout VALUES(1)"), "db
 
 my $error_handler_called = 0;
 $dbh2->{HandleError} = sub { $error_handler_called = 1; die $_[0]; };
-ok !defined eval { $dbh2->selectcol_arrayref("SELECT id FROM dbd_mysql_rt75353_innodb_lock_timeout FOR UPDATE") };
-my $error_message = $@;
+ok !defined eval { $dbh2->selectcol_arrayref("SELECT id FROM dbd_mysql_rt75353_innodb_lock_timeout FOR UPDATE") }, "dbh2: acquiring same lock as dbh1 on table dbd_mysql_rt75353_innodb_lock_timeout failed";
 $dbh2->{HandleError} = undef;
-ok $error_message, "dbh2: acquiring same lock as dbh1 on table dbd_mysql_rt75353_innodb_lock_timeout failed";
-
-like $error_message, qr/Lock wait timeout exceeded; try restarting transaction/, "dbh2: error message for acquiring lock is 'Lock wait timeout exceeded'";
+like $DBI::errstr, qr/Lock wait timeout exceeded; try restarting transaction/, "dbh2: error message for acquiring lock is 'Lock wait timeout exceeded'";
 ok $error_handler_called, "dbh2: error handler code ref was called";
 
 $dbh2->disconnect();


### PR DESCRIPTION
For tests in more cases it can be replaced by DBI's errstr function.