### PR TITLE
Fix compile warnings

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2049,7 +2049,7 @@ MYSQL *mariadb_dr_connect(
                   SV *sv_attr_val = hv_iterval(attrs, entry);
                   STRLEN attr_val_len;
                   char *attr_val  = SvPVutf8(sv_attr_val, attr_val_len);
-                  if (strlen(attr_name) != attr_name_len || strlen(attr_val) != attr_val_len)
+                  if (strlen(attr_name) != (STRLEN)attr_name_len || strlen(attr_val) != attr_val_len)
                   {
                     sock->net.last_errno = CR_CONNECTION_ERROR;
                     strcpy(sock->net.sqlstate, "HY000");

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -6511,8 +6511,8 @@ static bool parse_number(char *string, STRLEN len, char **end)
 
     /* length 0 -> not a number */
     /* Need to revisit this */
-    /*if (len == 0 || cp - string < len || seen_digit == 0) {*/
-    if (len == 0 || cp - string < len) {
+    /*if (len == 0 || string + len < cp || seen_digit == 0) {*/
+    if (len == 0 || string + len > cp) {
         return FALSE;
     }
 

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4914,6 +4914,8 @@ process:
 #endif
           default:
             NOT_REACHED;
+            int_val = 0;
+            int_type = "";
             break;
           }
 

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -178,9 +178,9 @@ count_params(imp_xxh_t *imp_xxh, pTHX_ char *statement, STRLEN statement_len, bo
     case '\'':
       /* Skip string */
       {
+        char end_token = c;
         if (ptr >= end)
           break;
-        char end_token = c;
         while (ptr < end && *ptr != end_token)
         {
           if (*ptr == '\\' && ptr+1 < end)
@@ -4836,11 +4836,11 @@ process:
           imp_sth->stmt->bind[i].buffer = (char *)fbh->data;
 
           if (DBIc_TRACE_LEVEL(imp_xxh) >= 2) {
+            char *ptr = (char*)buffer->buffer;
             unsigned long int j, m;
             m = buffer->buffer_length;
             if (m > *buffer->length)
               m = *buffer->length;
-            char *ptr = (char*)buffer->buffer;
             PerlIO_printf(DBIc_LOGPIO(imp_xxh),"\t\tbefore buffer->buffer: ");
             for (j = 0; j < m; j++) {
               PerlIO_printf(DBIc_LOGPIO(imp_xxh), "%c", *ptr++);
@@ -4858,11 +4858,11 @@ process:
           }
 
           if (DBIc_TRACE_LEVEL(imp_xxh) >= 2) {
+            char *ptr = (char*)buffer->buffer;
             unsigned long int j, m;
             m = buffer->buffer_length;
             if (m > *buffer->length)
               m = *buffer->length;
-            char *ptr = (char*)buffer->buffer;
             PerlIO_printf(DBIc_LOGPIO(imp_xxh),"\t\tafter buffer->buffer: ");
             for (j = 0; j < m; j++) {
               PerlIO_printf(DBIc_LOGPIO(imp_xxh), "%c", *ptr++);

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4912,6 +4912,9 @@ process:
             int_type= "LONGLONG INT";
             break;
 #endif
+          default:
+            NOT_REACHED;
+            break;
           }
 
           if (buffer->is_unsigned)

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -46,6 +46,10 @@
 #define PERL_STATIC_INLINE static
 #endif
 
+#ifndef NOT_REACHED
+#define NOT_REACHED assert(0)
+#endif
+
 #ifndef SVfARG
 #define SVfARG(p) ((void*)(p))
 #endif


### PR DESCRIPTION
Different compile warnings are produced by perl and gcc on RHEL6, RHEL7 and Debian 9. Fix/workaround all of them.