### PR TITLE
Fix crashing with older MySQL and new MariaDB clients when prepared statements are used

### DIFF
--- a/t/40server_prepare_crash.t
+++ b/t/40server_prepare_crash.t
@@ -10,9 +10,11 @@ require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 1, RaiseError => 1, AutoCommit => 0, mariadb_server_prepare => 1, mariadb_server_prepare_disable_fallback => 1 });
 
-plan tests => 44;
+plan tests => 45;
 
 my $sth;
+
+ok $dbh->selectall_hashref('SHOW ENGINES', 'Engine');
 
 ok $dbh->do("CREATE TEMPORARY TABLE t (i INTEGER NOT NULL, n LONGBLOB)");
 


### PR DESCRIPTION
Fixes commit e29584871e9fcae6ff0338a48bb76ad988e70ab1 as some MySQL and
some MariaDB clients set unitilized or zero value for name_length and
table_length of prepared statements. Problem affects all MySQL client
versions prior to version 5.5.0; all MariaDB clients 10.2.4 and new; and
all MariaDB Connector/C clients.

When using affected client, calculate length manually via strlen() to
prevent using uninitialized or zero length value.

Crash happen when prepared statements are enabled and calling some complex
DBI function like $dbh->selectall_hashref().