### PR TITLE
CVE-2018-2767: Handle SSL problems of MySQL and MariaDB clients

### DIFF
--- a/dbdimp.h
+++ b/dbdimp.h
@@ -306,18 +306,18 @@ PERL_STATIC_INLINE UV SvUV_nomg(pTHX_ SV *sv)
 #define HAVE_SSL_VERIFY
 #endif
 
-/* Use mysql_options with MYSQL_OPT_SSL_ENFORCE */
-#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50703 && MYSQL_VERSION_ID < 80000 && MYSQL_VERSION_ID != 60000
+/* Use mysql_options with MYSQL_OPT_SSL_ENFORCE (CVE-2015-3152, fix for MySQL) */
+#if !defined(MARIADB_BASE_VERSION) && !defined(DBD_MYSQL_EMBEDDED) && MYSQL_VERSION_ID >= 50703 && MYSQL_VERSION_ID < 80000 && MYSQL_VERSION_ID != 60000
 #define HAVE_SSL_ENFORCE
 #endif
 
-/* Use mysql_options with MYSQL_OPT_SSL_MODE */
-#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50711 && MYSQL_VERSION_ID != 60000
+/* Use mysql_options with MYSQL_OPT_SSL_MODE (CVE-2015-3152, fix for MySQL) */
+#if !defined(MARIADB_BASE_VERSION) && !defined(DBD_MYSQL_EMBEDDED) && MYSQL_VERSION_ID >= 50711 && MYSQL_VERSION_ID != 60000
 #define HAVE_SSL_MODE
 #endif
 
-/* Use mysql_options with MYSQL_OPT_SSL_MODE, but only SSL_MODE_REQUIRED is supported */
-#if !defined(MARIADB_BASE_VERSION) && ((MYSQL_VERSION_ID >= 50636 && MYSQL_VERSION_ID < 50700) || (MYSQL_VERSION_ID >= 50555 && MYSQL_VERSION_ID < 50600))
+/* Use mysql_options with MYSQL_OPT_SSL_MODE, but only SSL_MODE_REQUIRED is supported (CVE-2017-3305, fix for MySQL) */
+#if !defined(MARIADB_BASE_VERSION) && !defined(DBD_MYSQL_EMBEDDED) && ((MYSQL_VERSION_ID >= 50636 && MYSQL_VERSION_ID < 50700) || (MYSQL_VERSION_ID >= 50555 && MYSQL_VERSION_ID < 50600))
 #define HAVE_SSL_MODE_ONLY_REQUIRED
 #endif
 
@@ -325,11 +325,15 @@ PERL_STATIC_INLINE UV SvUV_nomg(pTHX_ SV *sv)
  * Check which SSL settings are supported by API at runtime
  */
 
-/* MYSQL_OPT_SSL_VERIFY_SERVER_CERT automatically enforce SSL mode */
+/* MYSQL_OPT_SSL_VERIFY_SERVER_CERT automatically enforce SSL mode (CVE-2015-3152 and CVE-2017-3305 and CVE-2018-2767, fix for MariaDB) */
 PERL_STATIC_INLINE bool ssl_verify_also_enforce_ssl(void) {
 #ifdef MARIADB_BASE_VERSION
 	unsigned long version = mysql_get_client_version();
-	return ((version >= 50544 && version < 50600) || (version >= 100020 && version < 100100) || version >= 100106);
+ #ifdef DBD_MYSQL_EMBEDDED
+	return ((version >= 50560 && version < 50600) || (version >= 100035 && version < 100100) || (version >= 100133 && version < 100200) || (version >= 100215 && version < 100300) || version >= 100307);
+ #else
+	return ((version >= 50556 && version < 50600) || (version >= 100031 && version < 100100) || (version >= 100123 && version < 100200) || (version >= 100206 && version < 100300) || version >= 100301);
+ #endif
 #else
 	return FALSE;
 #endif

--- a/lib/DBD/MariaDB.pm
+++ b/lib/DBD/MariaDB.pm
@@ -1286,10 +1286,6 @@ at least mariadb_ssl_ca_file or mariadb_ssl_ca_path.
 
 This means that your communication with the server will be encrypted.
 
-Please note that this can only work if you enabled SSL when compiling
-DBD::MariaDB; this is the default starting version 4.034.
-See L<DBD::MariaDB::INSTALL> for more details.
-
 =item mariadb_ssl_ca_file
 
 The path to a file in PEM format that contains a list of trusted SSL

--- a/lib/DBD/MariaDB/INSTALL.pod
+++ b/lib/DBD/MariaDB/INSTALL.pod
@@ -516,16 +516,6 @@ you may also try to link without gzip libraries.
 
 =back
 
-=head1 ENCRYPTED CONNECTIONS via SSL
-
-Connecting to your servers over an encrypted connection (SSL) is only possible
-if you enabled this setting at build time. Since version 4.034, this is the
-default.
-
-Attempting to connect to a server that requires an encrypted connection without
-first having L<DBD::MariaDB> compiled with the C<--ssl> option will result in
-an error that makes things appear as if your password is incorrect.
-
 
 =head1 MARIADB NATIVE CLIENT INSTALLATION
 

--- a/t/92ssl_connection.t
+++ b/t/92ssl_connection.t
@@ -13,17 +13,12 @@ my $have_ssl = eval { $dbh->selectrow_hashref("SHOW VARIABLES WHERE Variable_nam
 $dbh->disconnect();
 plan skip_all => 'Server does not support SSL connections' unless $have_ssl and $have_ssl->{Value} eq 'YES';
 
-plan tests => 4;
-
-$dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 0, mariadb_ssl => 1, mariadb_ssl_optional => 1 });
-ok(defined $dbh, 'DBD::MariaDB supports mariadb_ssl=1 with mariadb_ssl_optional=1 and connect to server') or diag('Error code: ' . ($DBI::err || 'none') . "\n" . 'Error message: ' . ($DBI::errstr || 'unknown'));
-
-ok(defined $dbh && defined $dbh->{mariadb_ssl_cipher}, 'SSL connection was established') and diag("mariadb_ssl_cipher is: ". $dbh->{mariadb_ssl_cipher});
+plan tests => 2;
 
 $dbh = DBI->connect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 0, mariadb_ssl => 1 });
 if (defined $dbh) {
   pass('DBD::MariaDB supports mariadb_ssl=1 without mariadb_ssl_optional=1 and connect to server');
-  ok(defined $dbh->{mariadb_ssl_cipher}, 'SSL connection was established');
+  ok(defined $dbh->{mariadb_ssl_cipher}, 'SSL connection was established') and diag("mariadb_ssl_cipher is: ". $dbh->{mariadb_ssl_cipher});
 } else {
   like($DBI::errstr, qr/^SSL connection error: /, 'DBD::MariaDB supports mariadb_ssl=1 without mariadb_ssl_optional=1 and fail because cannot enforce SSL encryption') or diag('Error message: ' . ($DBI::errstr || 'unknown'));
   is($DBI::err, 2026, 'DBD::MariaDB error code is SSL related') or diag('Error code: ' . ($DBI::err || 'unknown'));


### PR DESCRIPTION
* Fix version checks for library versions with SSL vulnerabilities (CVE-2015-3152, CVE-2017-3305, CVE-2018-2767)
* Fix test t/92ssl_connection.t, do not check for SSL when SSL is optional
* Remove information about SSL compile time option