### PR TITLE
In method data_sources() fix reading from uninitialized memory

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3140,6 +3140,7 @@ AV *mariadb_db_data_sources(SV *dbh, imp_dbh_t *imp_dbh, SV *attr)
 
     memcpy(SvPVX(sv), prefix, prefix_len);
     memcpy(SvPVX(sv)+prefix_len, row[0], lengths[0]);
+    *(SvPVX(sv)+prefix_len+lengths[0]) = '\0';
 
     SvPOK_on(sv);
     SvCUR_set(sv, prefix_len + lengths[0]);


### PR DESCRIPTION
Set nul term byte explicitly. Older perl versions prior to 5.16 have
problem when string in SvPVX() is not explicitly terminated by nul byte
even length of the string is correctly set by SvCUR_set() call.

This memory problem was detected by valgrind error:
Conditional jump or move depends on uninitialised value(s)