### PR TITLE
Try to mitigate CVE 2017-3302 libmysqlclient.so defect of leaking dangling pointers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -371,7 +371,6 @@ before_script:
   - export HARNESS_OPTIONS=j4
   - export RELEASE_TESTING=1
   - export CONNECTION_TESTING=1
-  - export SKIP_CRASH_TESTING=1
 
 script:
   - make realclean || true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,5 +37,4 @@ build_script:
 
 test_script:
   - set CONNECTION_TESTING=1
-  - set SKIP_CRASH_TESTING=1
   - perl -MConfig -e "system({$Config{make}} $Config{make}, @ARGV); exit((($? >> 8) | ($? & 127)) & 255)" test

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3294,12 +3294,8 @@ mariadb_st_prepare_sv(
 
     if (! imp_sth->stmt)
     {
-      if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-        PerlIO_printf(DBIc_LOGPIO(imp_xxh),
-                      "\t\tERROR: Unable to return MYSQL_STMT structure "
-                      "from mysql_stmt_init(): ERROR NO: %d ERROR MSG:%s\n",
-                      mysql_errno(imp_dbh->pmysql),
-                      mysql_error(imp_dbh->pmysql));
+      mariadb_dr_do_error(sth, mysql_errno(imp_dbh->pmysql), mysql_error(imp_dbh->pmysql), mysql_sqlstate(imp_dbh->pmysql));
+      return 0;
     }
 
     prepare_retval= mysql_stmt_prepare(imp_sth->stmt,

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3199,6 +3199,12 @@ mariadb_st_prepare_sv(
   D_imp_xxh(sth);
   D_imp_dbh_from_sth;
 
+  if (imp_sth->statement)
+  {
+    mariadb_dr_do_error(sth, CR_UNKNOWN_ERROR, "Statement is already prepared", "HY000");
+    return 0;
+  }
+
   statement = SvPVutf8_nomg(statement_sv, statement_len);
   imp_sth->statement = savepvn(statement, statement_len);
   imp_sth->statement_len = statement_len;
@@ -3284,11 +3290,6 @@ mariadb_st_prepare_sv(
     if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
       PerlIO_printf(DBIc_LOGPIO(imp_xxh),
                     "\t\tuse_server_side_prepare set\n");
-    /* do we really need this? If we do, we should return, not just continue */
-    if (imp_sth->stmt)
-      fprintf(stderr,
-              "ERROR: Trying to prepare new stmt while we have "
-              "already not closed one \n");
 
     imp_sth->stmt= mysql_stmt_init(imp_dbh->pmysql);
 

--- a/t/40server_prepare_crash.t
+++ b/t/40server_prepare_crash.t
@@ -77,12 +77,6 @@ ok $sth->finish();
 
 ok $dbh->do("SELECT 1 FROM t WHERE i = ?" . (" OR i = ?" x 10000), {}, (1) x (10001));
 
-if ($ENV{SKIP_CRASH_TESTING}) {
-  ok $dbh->disconnect();
-  Test::More->builder->skip("\$ENV{SKIP_CRASH_TESTING} is set") for (1..5);
-  exit;
-}
-
 # $sth2 is statement that cannot be executed as mysql server side prepared statement, so fallback must be allowed
 ok my $dbname = $dbh->selectrow_arrayref("SELECT DATABASE()")->[0];
 ok my $sth2 = $dbh->prepare("USE $dbname", { mariadb_server_prepare_disable_fallback => 0 });
@@ -99,5 +93,5 @@ $dbh = undef;
 # other - danging pointer exported
 my $sock1 = $sth->{mariadb_sock};
 my $sock2 = $sth2->{mariadb_sock};
-ok defined $sock1 && !$sock1 or diag "Your libmysqlclient.so is vulnerable to CVE 2017-3302 and can crash perl";
-ok defined $sock2 && !$sock2 or diag "Your libmysqlclient.so is vulnerable to CVE 2017-3302 and can crash perl";
+ok defined $sock1 && !$sock1 or diag "CVE 2017-3302 vulnerability detected, it can crash perl";
+ok defined $sock2 && !$sock2 or diag "CVE 2017-3302 vulnerability detected, it can crash perl";

--- a/t/cve-2017-3302.t
+++ b/t/cve-2017-3302.t
@@ -1,8 +1,4 @@
 # This must be minimal test, even strict or Test::More can hide real crash
-if ($ENV{SKIP_CRASH_TESTING}) {
-  print "1..0 # SKIP \$ENV{SKIP_CRASH_TESTING} is set\n";
-  exit;
-}
 no warnings 'once';
 use DBI;
 use vars qw($test_dsn $test_user $test_password $test_db);


### PR DESCRIPTION
Ensure that there is no unprepared, but allocated MYSQL_STMT structure which can cause memory corruption and crash in MySQL and MariaDB clients affected by CVE 2017-3302.

And also prevent another two NULL pointer dereference in DBD::MariaDB code.