### PR TITLE
Implement disconnect_all method

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -16,6 +16,7 @@ t/05dbcreate.t
 t/10connect.t
 t/11data_sources.t
 t/12embedded.t
+t/13disconnect.t
 t/15reconnect.t
 t/16dbi-get_info.t
 t/20createdrop.t

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -424,6 +424,7 @@ struct imp_drh_st {
     dbih_drc_t com;         /* MUST be first element in structure   */
     unsigned long int instances;
     bool non_embedded_started;
+    bool non_embedded_finished;
     bool embedded_started;
     SV *embedded_args;
     SV *embedded_groups;

--- a/t/13disconnect.t
+++ b/t/13disconnect.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require 'lib.pl';
+
+my $dbh1 = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1 });
+
+plan tests => 17;
+
+ok $dbh1->{Active};
+ok $dbh1->disconnect();
+ok !$dbh1->{Active};
+
+ok my $dbh2 = DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1 });
+ok my $dbh3 = DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1 });
+
+ok $dbh2->{Active};
+ok $dbh2->disconnect();
+ok !$dbh2->{Active};
+
+ok $dbh3->{Active};
+ok $dbh3->disconnect();
+ok !$dbh3->{Active};
+
+ok my $dbh4 = DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1 });
+ok our $dbh5 = DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1 });
+
+ok $dbh4->{Active};
+ok $dbh5->{Active};
+
+# install a handler so that a warning about unfreed resources gets caught
+$SIG{__WARN__} = sub { die @_ };
+
+DBI->disconnect_all();
+
+ok !$dbh4->{Active};
+ok !$dbh5->{Active};


### PR DESCRIPTION
Shutdown client library via mysql_server_end() only when unloading DBI
driver due to bugs in both MySQL and MariaDB client libraries.

See: https://jira.mariadb.org/browse/CONC-336