### PR TITLE
Store all taken MYSQL* connections and close them in disconnect_all()

### DIFF
--- a/dbdimp.h
+++ b/dbdimp.h
@@ -428,6 +428,7 @@ struct imp_drh_st {
     bool embedded_started;
     SV *embedded_args;
     SV *embedded_groups;
+    AV *taken_pmysqls;      /* List of active MYSQL* structures from take_imp_data() */
 };
 
 
@@ -567,6 +568,7 @@ struct imp_sth_st {
  * These defines avoid name clashes for multiple statically linked DBD's	*/
 #define dbd_init		mariadb_dr_init
 #define dbd_discon_all		mariadb_dr_discon_all
+#define dbd_take_imp_data	mariadb_db_take_imp_data
 #define dbd_db_login6_sv	mariadb_db_login6_sv
 #define dbd_db_commit		mariadb_db_commit
 #define dbd_db_rollback		mariadb_db_rollback


### PR DESCRIPTION
Track all take_imp_data() calls and store MYSQL* pointers into global
driver array. When a new DBI connection with imp_data is going to be
established, check that imp_data comes from tracked take_imp_data() call
and that MYSQL* pointer inside is valid. After reusing imp_data remove
MYSQL* pointer from global driver array, so it cannot be again reused.

When disconnect_all() is called, close also tracked connections from
take_imp_data() which were not yet reused. This fixes memory leaks when
caller of take_imp_data() discard taken data and not reuse them. Also it
ensure that these connections are properly closed prior perl process
finished.

This change also fixes segfaults and memory corruptions when same taken
imp_data are passed to the two different connections. Now instead of
segfault it throws DBI error.