### PR TITLE
Fix calculation of buffer size for client side placeholder replacing

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -665,17 +665,17 @@ static char *parse_params(
 
   /* Calculate the number of bytes being allocated for the statement */
   alen= slen;
-
   for (i= 0, ph= params; i < num_params; i++, ph++)
   {
+    alen--; /* Erase '?' */
     if (!ph->value)
-      alen+= 3;  /* Erase '?', insert 'NULL' */
+      alen += 4;  /* insert 'NULL' */
     else
-      alen+= 2+ph->len+1;
+      alen += 2 + 2*ph->len; /* 2 bytes for quotes and in the worst case two bytes for each character */
   }
 
-  /* Allocate memory, why *2, well, because we have ptr and statement_ptr */
-  New(908, salloc, alen*2, char);
+  /* +1 for null term byte */
+  New(908, salloc, alen+1, char);
   ptr= salloc;
 
   i= 0;


### PR DESCRIPTION
Each bind parameter needs buffer at least of size 2*len (worst case
every character is escaped) plus 2 bytes for quotes. Final length is then
increased by one for nul term byte.

Also remove misleading/wrong comment about *2 as it does not make sense.