### PR TITLE
Fix generating dsn for tests and check for errors in dsn

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -102,9 +102,9 @@ for my $key (qw(testdb testhost testuser testpassword testsocket testport cflags
   Configure($opt, $source, $key);
 }
 
-#if we have a testport but no host, assume localhost
+#if we have a testport but no host, assume 127.0.0.1
 if ( $opt->{testport} && !$opt->{testhost} ) {
-  $opt->{testhost} = 'localhost';
+  $opt->{testhost} = '127.0.0.1';
   $source->{testhost} = 'guessed';
 }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -205,9 +205,9 @@ my $fileName = File::Spec->catfile("t", "MariaDB.mtest");
 	      "\$::test_password = \$opt->{'testpassword'};\n" .
 	      "\$::test_db = \$opt->{'testdb'};\n" .
 	      "\$::test_dsn = \"DBI:MariaDB:\$::test_db\";\n" .
-	      "\$::test_dsn .= \";mariadb_socket=\$::test_socket\" if \$::test_socket;\n" .
               "\$::test_dsn .= \":\$::test_host\" if \$::test_host;\n" .
 	      "\$::test_dsn .= \":\$::test_port\" if \$::test_port;\n".
+	      "\$::test_dsn .= \";mariadb_socket=\$::test_socket\" if \$::test_socket;\n" .
 	      "\$::test_mysql_config = \$opt->{'mysql_config'} if \$source->{'mysql_config'} eq 'User\\'s choice';\n" .
 	      "\$::test_cflags = \$opt->{'cflags'} if \$source->{'cflags'} eq 'User\\'s choice';\n" .
 	      "\$::test_libs = \$opt->{'libs'} if \$source->{'libs'} eq 'User\\'s choice';\n" .

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1434,6 +1434,20 @@ static bool mariadb_dr_connect(
     return FALSE;
   }
 
+  /* host=localhost means to connect via unix socket, host=embedded means to use embedded server, so do not allow specifying port */
+  if (port && host && (strcmp(host, "localhost") == 0 || strcmp(host, "embedded") == 0))
+  {
+    mariadb_dr_do_error(dbh, CR_CONNECTION_ERROR, "Connection error: port cannot be specified when host is localhost or embedded", "HY000");
+    return FALSE;
+  }
+
+  /* when connecting via unix socket do not allow specifying port or host != localhost */
+  if (mysql_socket && (port || (host && strcmp(host, "localhost") != 0)))
+  {
+    mariadb_dr_do_error(dbh, CR_CONNECTION_ERROR, "Connection error: host or port cannot be specified together with mariadb_socket", "HY000");
+    return FALSE;
+  }
+
   if (host && strcmp(host, "embedded") == 0)
   {
 #ifndef HAVE_EMBEDDED


### PR DESCRIPTION
Disallow DBI connection when using wrong combination of mariadb_socket, host and port parameters