### PR TITLE
Fix last insert id workaround for MySQL 5.7 and 8.0 client versions

### DIFF
--- a/dbdimp.h
+++ b/dbdimp.h
@@ -313,6 +313,25 @@ PERL_STATIC_INLINE UV SvUV_nomg(pTHX_ SV *sv)
 #endif
 
 /*
+ * MySQL 5.7 below 5.7.18 and MySQL 8.0.0 are affected by Bug #78778.
+ * mysql_insert_id() is reset to 0 after performing SELECT operation.
+ * https://bugs.mysql.com/bug.php?id=78778
+ */
+#if !defined(MARIADB_BASE_VERSION) && ((MYSQL_VERSION_ID >= 50700 && MYSQL_VERSION_ID <= 50717) || MYSQL_VERSION_ID == 80000)
+#define HAVE_BROKEN_INSERT_ID_AFTER_SELECT
+#endif
+
+/*
+ * MySQL 5.7, MySQL 8.0, MySQL Connector/C 6.1.5 and higher are affected by Bug #89139.
+ * mysql_insert_id() is reset to 0 after calling mysql_ping() C function.
+ * Once Bug #89139 is fixed we can adjust the upper bound of this check.
+ * https://bugs.mysql.com/bug.php?id=89139
+ */
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50700 && (MYSQL_VERSION_ID < 60100 || MYSQL_VERSION_ID >= 60105)
+#define HAVE_BROKEN_INSERT_ID_AFTER_PING
+#endif
+
+/*
  * Check which SSL settings are supported by API at compile time
  */
 

--- a/t/31insertid.t
+++ b/t/31insertid.t
@@ -43,11 +43,7 @@ is $dbh->last_insert_id(undef, undef, undef, undef), 1, "insert id == last_inser
 ok $sth->execute("Patrick");
 
 $dbh->ping();
-SKIP: {
-  skip 'using libmysqlclient 5.7 or up we now have an empty dbh insertid',
-    1, if ($dbh->{mariadb_clientversion} >= 50700 && $dbh->{mariadb_clientversion} < 50718) || ($dbh->{mariadb_clientversion} >= 60105 && $dbh->{mariadb_clientversion} < 69999) || $dbh->{mariadb_clientversion} == 80000;
   is $dbh->last_insert_id(undef, undef, undef, undef), 2, "insert id == last_insert_id()";
-}
 
 ok (my $sth2= $dbh->prepare("SELECT max(id) FROM dbd_mysql_t31"));
 
@@ -60,12 +56,8 @@ ok ($max_id= $sth2->fetch());
 
 ok defined $max_id;
 
-SKIP: {
-  skip 'using libmysqlclient 5.7 below 5.7.18 we now have an empty dbh insertid',
-    1, if ($dbh->{mariadb_clientversion} >= 50700 && $dbh->{mariadb_clientversion} < 50718) || ($dbh->{mariadb_clientversion} >= 60105 && $dbh->{mariadb_clientversion} < 69999) || $dbh->{mariadb_clientversion} == 80000;
   cmp_ok $dbh->{mariadb_insertid}, '==', $max_id->[0],
     "dbh insert id $dbh->{'mariadb_insertid'} == max(id) $max_id->[0] in dbd_mysql_t31";
-}
 cmp_ok $sth->{mariadb_insertid}, '==', $max_id->[0],
   "sth insert id $sth->{'mariadb_insertid'} == max(id) $max_id->[0]  in dbd_mysql_t31";
 


### PR DESCRIPTION
MySQL 5.7 below 5.7.18 and MySQL 8.0.0 are affected by Bug #78778.
mysql_insert_id() is reset to 0 after performing SELECT operation.

As a workaround prior to issuing mysql query we store value of last insert
id. If query returns result set then we know that it was SELECT operation
and so after that we restore previous value of last insert id.

MySQL 5.7, MySQL 8.0, MySQL Connector/C 6.1.5 and higher are affected by
Bug #89139. mysql_insert_id() is reset to 0 after calling mysql_ping() C
function.

As a workaround prior to calling mysql_ping() function we store value of
last insert id. After function finish we restore previous value of last
insert id.

DBD::MariaDB had already second workaround but with wrong version check.
This commit therefore fix version check for second workaround and declare
helper macros for determining if workaround is needed.

Applying both workaround fixes $dbh->last_insert_id() method and now can be
called also when compiled with those affected MySQL client versions, even
after $dbh->ping() method or performing SELECT operation. So skip blocks
for last insert id tests are now removed and tests are enabled for all
MySQL client versions.

Fixes: 26ff601f518c76b8900764780e867b74e20824a1
See: https://bugs.mysql.com/bug.php?id=78778
See: https://bugs.mysql.com/bug.php?id=89139