### PR TITLE
Fix placeholders replacement for MySQL client version >= 5.7.6

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -50,6 +50,7 @@ t/42bindparam.t
 t/43count_params.t
 t/44call_placeholder.t
 t/44limit_placeholder.t
+t/45bind_no_backslash_escapes.t
 t/50chopblanks.t
 t/50commit.t
 t/51bind_type_guessing.t

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -833,7 +833,11 @@ static char *parse_params(
           if (quote_value)
           {
             *ptr++ = '\'';
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50706 && MYSQL_VERSION_ID != 60000
+            ptr += mysql_real_escape_string_quote(sock, ptr, ph->value, ph->len, '\'');
+#else
             ptr += mysql_real_escape_string(sock, ptr, ph->value, ph->len);
+#endif
             *ptr++ = '\'';
           }
           else
@@ -6018,7 +6022,11 @@ SV* mariadb_db_quote(SV *dbh, SV *str, SV *type)
       sptr = SvPVX(result);
 
       *sptr++ = '\'';
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50706 && MYSQL_VERSION_ID != 60000
+      sptr += mysql_real_escape_string_quote(imp_dbh->pmysql, sptr, ptr, len, '\'');
+#else
       sptr += mysql_real_escape_string(imp_dbh->pmysql, sptr, ptr, len);
+#endif
       *sptr++ = '\'';
     }
 

--- a/t/45bind_no_backslash_escapes.t
+++ b/t/45bind_no_backslash_escapes.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require 'lib.pl';
+
+my $id1 = 'session:06b6d2138df949524092eefc066ee5ab3598bf96';
+my $id2 = q(string\\string"string'string);
+my $id2_quoted_no_backslash = q('string\\string"string''string');
+
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 1, AutoCommit => 0 });
+
+if ($dbh->{mariadb_serverversion} < 50001) {
+    plan skip_all => "Servers < 5.0.1 do not support sql_mode NO_BACKSLASH_ESCAPES";
+}
+
+plan tests => 24;
+
+ok $dbh->do('CREATE TEMPORARY TABLE t(id VARCHAR(255), value TEXT)');
+ok $dbh->do('INSERT INTO t(id, value) VALUES(?, ?)', undef, $id1, 'value1');
+ok $dbh->do('INSERT INTO t(id, value) VALUES(?, ?)', undef, $id2, 'value2');
+
+ok $dbh->do("SET sql_mode = 'NO_BACKSLASH_ESCAPES'");
+
+is $dbh->quote($id2), $id2_quoted_no_backslash;
+
+for my $server_prepare (0, 1) {
+
+    $dbh->{mariadb_server_prepare} = $server_prepare;
+    $dbh->{mariadb_server_prepare_disable_fallback} = 1;
+
+    ok my $sth = $dbh->prepare('SELECT * FROM t WHERE id = ?');
+    ok $sth->bind_param(1, $id1);
+    ok $sth->execute();
+    is_deeply $sth->fetchall_arrayref(), [ [ $id1, 'value1' ] ];
+    ok $sth->finish();
+
+    ok $sth->bind_param(1, $id2);
+    ok $sth->execute();
+    is_deeply $sth->fetchall_arrayref(), [ [ $id2, 'value2' ] ];
+    ok $sth->finish();
+
+}
+
+ok $dbh->disconnect();


### PR DESCRIPTION
MySQL client in version 5.7.6 changed API of the mysql_real_escape_string()
function in backward incompatible way. When SQL mode NO_BACKSLASH_ESCAPES
is active then this function returns value ULONG_MAX. When this number is
added to string pointer it effectively means subtraction by one. So it
removes last added character from string and totally breaks quoting.

New function mysql_real_escape_string_quote() which is available only in
MySQL client (since version 5.7.6) with passing '\\'' to the last argument
does the same thing as older versions of mysql_real_escape_string() used to
do.

Fixes: https://github.com/perl5-dbi/DBD-mysql/issues/221
See: https://stackoverflow.com/a/50933703/9963391