### PR TITLE
Fix parsing $test_dsn and ensure that it is always filled

### DIFF
--- a/t/00base.t
+++ b/t/00base.t
@@ -3,12 +3,6 @@ use warnings;
 
 use Test::More tests => 6;
 
-#
-#   Include lib.pl
-#
-use lib 't', '.';
-require 'lib.pl';
-
 # Base DBD Driver Test
 BEGIN {
     my $tb = Test::More->builder;

--- a/t/05dbcreate.t
+++ b/t/05dbcreate.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More ;
 use DBI;
+use DBD::MariaDB;
 $|= 1;
 
 use vars qw($test_user $test_password $test_db $test_dsn);
@@ -10,8 +11,10 @@ use lib 't', '.';
 require 'lib.pl';
 
 # remove database from DSN
-my $test_dsn_without_db = $test_dsn;
-$test_dsn_without_db =~ s/^(DBI:[^:]+):(?:[^:;]+)([:;]?)/$1:$2/;
+my ($dbi_dsn, $driver_dsn) = ($test_dsn =~ /^([^:]*:[^:]*:)(.*)$/);
+my $attr_dsn = DBD::MariaDB->parse_dsn($driver_dsn);
+delete $attr_dsn->{database};
+my $test_dsn_without_db = $dbi_dsn . join ';', map { $_ . '=' . $attr_dsn->{$_} } sort keys %{$attr_dsn};
 
 sub fatal_error {
     my ($message) = @_;

--- a/t/lib.pl
+++ b/t/lib.pl
@@ -3,7 +3,9 @@ use warnings;
 
 use Test::More;
 use FindBin qw($Bin);
-use vars qw($test_dsn $test_user $test_password);
+use vars qw($test_dsn $test_user $test_password $test_db);
+
+use DBD::MariaDB;
 
 $| = 1; # flush stdout asap to keep in sync with stderr
 
@@ -16,6 +18,15 @@ BAIL_OUT "Cannot execute $file: $@" if -e $file and not eval { require $file };
 $::test_dsn      = $::test_dsn      || $ENV{'DBI_DSN'}   || 'DBI:MariaDB:database=test';
 $::test_user     = $::test_user     || $ENV{'DBI_USER'}  || '';
 $::test_password = $::test_password || $ENV{'DBI_PASS'}  || '';
+
+BAIL_OUT "DBI test_dsn is not valid" unless $::test_dsn =~ /^[Dd][Bb][Ii]:MariaDB:/;
+
+if (not $::test_db) {
+    my $driver_dsn = $::test_dsn;
+    $driver_dsn =~ s/^[^:]*:[^:]*://;
+    $::test_db = DBD::MariaDB->parse_dsn($driver_dsn)->{database};
+    $::test_db = 'test' unless $::test_db;
+}
 
 sub DbiTestConnect {
     my $err;


### PR DESCRIPTION
Without it some tests are failing on strange errors:

Use of uninitialized value $test_db in concatenation (.) or string at t/05dbcreate.t line 59.
Use of uninitialized value $test_db in concatenation (.) or string at t/05dbcreate.t line 73.
Use of uninitialized value $test_db in concatenation (.) or string at t/11data_sources.t line 29.
DBD::MariaDB::db prepare failed: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '' at line 1 at t/cve-2017-3302.t line 16.

This problem found by Debian Perl Group.