### PR TITLE
Fix support for client side placeholder replacement with LIMIT keyword

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -687,14 +687,17 @@ static char *parse_params(
     /* LIMIT should be the last part of the query, in most cases */
     if (! limit_flag)
     {
-      /*
-        it would be good to be able to handle any number of cases and orders
-      */
-      if ((*statement_ptr == 'l' || *statement_ptr == 'L') &&
-          (!strncmp(statement_ptr+1, "imit ?", 6) ||
-           !strncmp(statement_ptr+1, "IMIT ?", 6)))
+      if (statement_ptr+4 < statement_ptr_end)
       {
-        limit_flag = TRUE;
+        char *s = statement_ptr;
+        if ((s[0] == 'l' || s[0] == 'L') &&
+            (s[1] == 'i' || s[1] == 'I') &&
+            (s[2] == 'm' || s[2] == 'M') &&
+            (s[3] == 'i' || s[3] == 'I') &&
+            (s[4] == 't' || s[4] == 'T'))
+        {
+          limit_flag = TRUE;
+        }
       }
     }
     switch (*statement_ptr)

--- a/t/44limit_placeholder.t
+++ b/t/44limit_placeholder.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 1, AutoCommit => 0, mariadb_server_prepare => 1 });
 
-plan tests => 26;
+plan tests => 38;
 
 ok $dbh->do('CREATE TEMPORARY TABLE t(id INT)');
 ok $dbh->do('CREATE TEMPORARY TABLE t2(id INT)');
@@ -43,5 +43,20 @@ ok $sth->finish();
 ok $dbh->do('INSERT INTO t2(id) SELECT id FROM t ORDER BY id LIMIT ? OFFSET ?', undef, 1, 0);
 is_deeply $dbh->selectall_arrayref('SELECT id FROM t2'), [ [10] ];
 ok $dbh->do('TRUNCATE TABLE t2');
+
+ok $sth = $dbh->prepare('select id from t order by id LiMIt    ?,?');
+ok $sth->execute(0, 1);
+is_deeply $sth->fetchall_arrayref(), [ [10] ];
+ok $sth->finish();
+
+ok $sth = $dbh->prepare('select id from t order by id LiMIt  0  ,?');
+ok $sth->execute(1);
+is_deeply $sth->fetchall_arrayref(), [ [10] ];
+ok $sth->finish();
+
+ok $sth = $dbh->prepare('select id from t order by id lImIt  1  OFFSET  ?');
+ok $sth->execute(0);
+is_deeply $sth->fetchall_arrayref(), [ [10] ];
+ok $sth->finish();
 
 ok $dbh->disconnect();


### PR DESCRIPTION
LIMIT keyword needs to be parsed case-insensitive and after it there can be
more whitespaces. Also placeholder can be put after OFFSET keyword.

Add more tests to check that LIMIT/OFFSET supports placeholders correctly.

Fixes: https://github.com/perl5-dbi/DBD-mysql/pull/34