### PR TITLE
Disable Native Linux asynchronous I/O subsystem on Travis also when initializing database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -337,7 +337,7 @@ before_install:
       mkdir -p "$SANDBOX_HOME" || exit 1 ;
       ln -s "$SANDBOX_CACHE_FILE" "$SANDBOX_FILE" || exit 1 ;
       if [ `echo "$VERSION" | sed 's/\.//;s/\..*//'` -ge 55 ]; then
-        SANDBOX_OPTIONS="$SANDBOX_OPTIONS --my_clause=innodb_use_native_aio=0" ;
+        SANDBOX_OPTIONS="$SANDBOX_OPTIONS --init_options=--innodb_use_native_aio=0 --my_clause=innodb_use_native_aio=0" ;
       fi ;
     fi
   - if [ "$CONC_DB" = "MySQL" ]; then


### PR DESCRIPTION
MySQL::Sandbox uses different options for initialization database server and
for running database server.