### PR TITLE
Fix allocating and releasing memory

### DIFF
--- a/MariaDB.xs
+++ b/MariaDB.xs
@@ -308,7 +308,7 @@ do(dbh, statement, attr=Nullsv, ...)
     {
       /*  Handle binding supplied values to placeholders	   */
       /*  Assume user has passed the correct number of parameters  */
-      Newz(0, params, sizeof(*params)*num_params, struct imp_sth_ph_st);
+      Newz(0, params, num_params, struct imp_sth_ph_st);
       for (i= 0;  i < num_params;  i++)
       {
         SV *param= ST(i+3);

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -545,9 +545,9 @@ int free_embedded_options(char ** options_list, int options_count)
   for (i= 0; i < options_count; i++)
   {
     if (options_list[i])
-      free(options_list[i]);
+      Safefree(options_list[i]);
   }
-  free(options_list);
+  Safefree(options_list);
 
   return 1;
 }
@@ -582,13 +582,9 @@ char **fill_out_embedded_options(PerlIO *stream,
   char c;
   char *ptr;
   char **options_list= NULL;
+  dTHX;
 
-  if (!(options_list= (char **) calloc(cnt, sizeof(char *))))
-  {
-    PerlIO_printf(stream,
-                  "Initialize embedded server. Out of memory \n");
-    return NULL;
-  }
+  Newz(908, options_list, cnt, char *);
 
   ptr= options;
   ind= 0;
@@ -602,9 +598,7 @@ char **fill_out_embedded_options(PerlIO *stream,
   if (options_type == 1)
   {
     /* first item in server_options list is ignored. fill it with \0 */
-    if (!(options_list[0]= calloc(1,sizeof(char))))
-      return NULL;
-
+    Newz(908, options_list[0], 1, char);
     ind++;
   }
 
@@ -616,10 +610,7 @@ char **fill_out_embedded_options(PerlIO *stream,
       len= ptr - options;
       if (c == ',')
         len--;
-      if (!(options_list[ind]=calloc(len+1,sizeof(char))))
-        return NULL;
-
-      strncpy(options_list[ind], options, len);
+      options_list[ind] = savepvn(options, len);
       ind++;
       options= ptr;
     }


### PR DESCRIPTION
Use only Perl's alloc/free functions. Perl redefines C library alloc
functions (malloc, realloc, free) to its own memory allocation and
therefore it is not safe to use C library functions which allocate memory.

Perl doesn't redefine calloc() so its usage is not safe as far as it
allocates using C library memory management but frees with Perl's.

See also: https://github.com/gooddata/DBD-MariaDB/issues/91