### PR TITLE
Fix escaping placeholders when sql_mode is NO_BACKSLASH_ESCAPES

### DIFF
--- a/dbdimp.h
+++ b/dbdimp.h
@@ -42,6 +42,11 @@
 #define MY_CS_PRIMARY 32
 #endif
 
+/* Macro is available in mysql_com.h, but not defined in older MySQL versions */
+#ifndef SERVER_STATUS_NO_BACKSLASH_ESCAPES
+#define SERVER_STATUS_NO_BACKSLASH_ESCAPES 512
+#endif
+
 /* Macro is not defined in some MariaDB versions */
 #ifndef CR_NO_RESULT_SET
 #define CR_NO_RESULT_SET 2053

--- a/t/45bind_no_backslash_escapes.t
+++ b/t/45bind_no_backslash_escapes.t
@@ -18,6 +18,10 @@ if ($dbh->{mariadb_serverversion} < 50001) {
     plan skip_all => "Servers < 5.0.1 do not support sql_mode NO_BACKSLASH_ESCAPES";
 }
 
+if ($dbh->{mariadb_clientversion} < 50001) {
+    $id2_quoted_no_backslash = q(X'737472696E675C737472696E6722737472696E6727737472696E67');
+}
+
 plan tests => 24;
 
 ok $dbh->do('CREATE TEMPORARY TABLE t(id VARCHAR(255), value TEXT)');


### PR DESCRIPTION
When MySQL client library version differs from MySQL/MariaDB server version
and sql_mode is NO_BACKSLASH_ESCAPES then mysql_real_escape_string() does
not have to work.

As a workaround use mysql_hex_string() for escaping placeholders as this
function does not produce any backslashes or quotes characters. So it does
not conflict with NO_BACKSLASH_ESCAPES.