### PR TITLE
Set default read, write and connect timeout to 60 seconds

### DIFF
--- a/lib/DBD/MariaDB.pod
+++ b/lib/DBD/MariaDB.pod
@@ -184,19 +184,19 @@ between client and server will be compressed.
 
 If your DSN contains the option C<mariadb_connect_timeout=##>, the connect
 request to the server will timeout if it has not been successful after the given
-number of seconds.
+number of seconds. Zero value means infinite timeout. Default is 60 seconds.
 
 =item mariadb_write_timeout
 
 If your DSN contains the option C<mariadb_write_timeout=##>, the write operation
 to the server will timeout if it has not been successful after the given number
-of seconds.
+of seconds. Zero value means infinite timeout. Default is 60 seconds.
 
 =item mariadb_read_timeout
 
 If your DSN contains the option C<mariadb_read_timeout=##>, the read operation
 to the server will timeout if it has not been successful after the given number
-of seconds.
+of seconds. Zero value means infinite timeout. Default is 60 seconds.
 
 =item mariadb_init_command
 


### PR DESCRIPTION
Default value was previously zero (=infinity) which means that DBD::MariaDB
may have wait forever and could freeze.

This change also updates code for handling timeouts when client library
have them broken.