### PR TITLE
Allow to set zero timeouts and allow to set timeouts also for broken clients

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1695,9 +1695,9 @@ static bool mariadb_dr_connect(
         }
 
         (void)hv_stores(processed, "mariadb_connect_timeout", &PL_sv_yes);
-        if ((svp = hv_fetchs(hv, "mariadb_connect_timeout", FALSE)) && *svp && SvTRUE(*svp))
+        if ((svp = hv_fetchs(hv, "mariadb_connect_timeout", FALSE)) && *svp)
         {
-          UV uv = SvUV_nomg(*svp);
+          UV uv = SvUV(*svp);
           unsigned int to = (uv <= UINT_MAX ? uv : UINT_MAX);
           if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
             PerlIO_printf(DBIc_LOGPIO(imp_xxh),
@@ -1708,9 +1708,9 @@ static bool mariadb_dr_connect(
         }
 
         (void)hv_stores(processed, "mariadb_write_timeout", &PL_sv_yes);
-        if ((svp = hv_fetchs(hv, "mariadb_write_timeout", FALSE)) && *svp && SvTRUE(*svp))
+        if ((svp = hv_fetchs(hv, "mariadb_write_timeout", FALSE)) && *svp)
         {
-          UV uv = SvUV_nomg(*svp);
+          UV uv = SvUV(*svp);
           unsigned int to = (uv <= UINT_MAX ? uv : UINT_MAX);
           if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
             PerlIO_printf(DBIc_LOGPIO(imp_xxh),
@@ -1729,9 +1729,9 @@ static bool mariadb_dr_connect(
         }
 
         (void)hv_stores(processed, "mariadb_read_timeout", &PL_sv_yes);
-        if ((svp = hv_fetchs(hv, "mariadb_read_timeout", FALSE)) && *svp && SvTRUE(*svp))
+        if ((svp = hv_fetchs(hv, "mariadb_read_timeout", FALSE)) && *svp)
         {
-          UV uv = SvUV_nomg(*svp);
+          UV uv = SvUV(*svp);
           unsigned int to = (uv <= UINT_MAX ? uv : UINT_MAX);
           if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
             PerlIO_printf(DBIc_LOGPIO(imp_xxh),

--- a/lib/DBD/MariaDB.pod
+++ b/lib/DBD/MariaDB.pod
@@ -184,19 +184,19 @@ between client and server will be compressed.
 
 If your DSN contains the option C<mariadb_connect_timeout=##>, the connect
 request to the server will timeout if it has not been successful after the given
-number of seconds.
+number of seconds. Zero value means infinite timeout.
 
 =item mariadb_write_timeout
 
 If your DSN contains the option C<mariadb_write_timeout=##>, the write operation
 to the server will timeout if it has not been successful after the given number
-of seconds.
+of seconds. Zero value means infinite timeout.
 
 =item mariadb_read_timeout
 
 If your DSN contains the option C<mariadb_read_timeout=##>, the read operation
 to the server will timeout if it has not been successful after the given number
-of seconds.
+of seconds. Zero value means infinite timeout.
 
 =item mariadb_init_command
 


### PR DESCRIPTION
Zero value means infinite timeout.

Also allow to set read and write timeout also for broken MariaDB Connector/C clients. Zero value (=infinite) value is simulated by maximal timeout value in those broken clients.