### PR TITLE
Fix last insert id workaround also for prepared statements

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4276,7 +4276,7 @@ my_ulonglong mariadb_st_internal_execute(
  **************************************************************************/
 
 my_ulonglong mariadb_st_internal_execute41(
-                                         SV *sth,
+                                         SV *h,
                                          char *sbuf,
                                          STRLEN slen,
                                          bool has_params,
@@ -4293,7 +4293,7 @@ my_ulonglong mariadb_st_internal_execute41(
   MYSQL_STMT *stmt = *stmt_ptr;
   my_ulonglong rows=0;
   bool reconnected = FALSE;
-  D_imp_xxh(sth);
+  D_imp_xxh(h);
 
   if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
     PerlIO_printf(DBIc_LOGPIO(imp_xxh),
@@ -4319,7 +4319,7 @@ my_ulonglong mariadb_st_internal_execute41(
     }
     else
     {
-      if (!mariadb_db_reconnect(sth, stmt))
+      if (!mariadb_db_reconnect(h, stmt))
         goto error;
       reconnected = TRUE;
     }
@@ -4331,7 +4331,7 @@ my_ulonglong mariadb_st_internal_execute41(
   if (!reconnected)
   {
     execute_retval = mysql_stmt_execute(stmt);
-    if (execute_retval && mariadb_db_reconnect(sth, stmt))
+    if (execute_retval && mariadb_db_reconnect(h, stmt))
       reconnected = TRUE;
   }
   if (reconnected)
@@ -4340,12 +4340,12 @@ my_ulonglong mariadb_st_internal_execute41(
     stmt = mysql_stmt_init(*svsock);
     if (!stmt)
     {
-      mariadb_dr_do_error(sth, mysql_errno(*svsock), mysql_error(*svsock), mysql_sqlstate(*svsock));
+      mariadb_dr_do_error(h, mysql_errno(*svsock), mysql_error(*svsock), mysql_sqlstate(*svsock));
       return -1;
     }
     if (mysql_stmt_prepare(stmt, sbuf, slen))
     {
-      mariadb_dr_do_error(sth, mysql_stmt_errno(stmt), mysql_stmt_error(stmt), mysql_stmt_sqlstate(stmt));
+      mariadb_dr_do_error(h, mysql_stmt_errno(stmt), mysql_stmt_error(stmt), mysql_stmt_sqlstate(stmt));
       mysql_stmt_close(stmt);
       return -1;
     }
@@ -4420,7 +4420,7 @@ error:
                   "     errno %d err message %s\n",
                   mysql_stmt_errno(stmt),
                   mysql_stmt_error(stmt));
-  mariadb_dr_do_error(sth, mysql_stmt_errno(stmt), mysql_stmt_error(stmt),
+  mariadb_dr_do_error(h, mysql_stmt_errno(stmt), mysql_stmt_error(stmt),
            mysql_stmt_sqlstate(stmt));
   mysql_stmt_reset(stmt);
 

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4306,12 +4306,22 @@ my_ulonglong mariadb_st_internal_execute41(
     *result = NULL;
   }
 
+  if (!*svsock)
+  {
+    if (!mariadb_db_reconnect(h, NULL))
+    {
+      mariadb_dr_do_error(h, CR_SERVER_GONE_ERROR, "MySQL server has gone away", "HY000");
+      return -1;
+    }
+    reconnected = TRUE;
+  }
+
   /*
     If were performed any changes with ph variables
     we have to rebind them
   */
 
-  if (has_params && !(*has_been_bound))
+  if (!reconnected && has_params && !(*has_been_bound))
   {
     if (mysql_stmt_bind_param(stmt,bind) == 0)
     {

--- a/t/31insertid.t
+++ b/t/31insertid.t
@@ -11,13 +11,17 @@ require "lib.pl";
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
 			    {RaiseError => 1});
 
-plan tests => 33;
+plan tests => 3 + 2*30;
 
 SKIP: {
     skip 'SET @@auto_increment_offset needs MySQL >= 5.0.2', 2 unless $dbh->{mariadb_serverversion} >= 50002;
     ok $dbh->do('SET @@auto_increment_offset = 1');
     ok $dbh->do('SET @@auto_increment_increment = 1');
 }
+
+for my $mariadb_server_prepare (0, 1) {
+
+$dbh->{mariadb_server_prepare} = $mariadb_server_prepare;
 
 my $create = <<EOT;
 CREATE TEMPORARY TABLE dbd_mysql_t31 (
@@ -79,5 +83,7 @@ ok $sth->finish();
 ok $sth2->finish();
 
 ok $dbh->do('DROP TABLE dbd_mysql_t31');
+
+}
 
 ok $dbh->disconnect();


### PR DESCRIPTION
MySQL 5.7 below 5.7.18 and MySQL 8.0.0 are affected by Bug #78778.
mysql_insert_id() is reset to 0 after performing SELECT operation.

This applies also for execution of prepared SELECT statement.

Fixes: 61dfddbf48b9c52fe06f5c3a6ba3840dc34c202e
See: https://bugs.mysql.com/bug.php?id=78778