### PR TITLE
Set default session collation to utf8mb4_unicode_ci

### DIFF
--- a/t/05dbcreate.t
+++ b/t/05dbcreate.t
@@ -67,7 +67,19 @@ if ($charset ne 'utf8mb4') {
         my $failed = not eval { $dbh->do("ALTER DATABASE " . $dbh->quote_identifier($test_db) . " CHARACTER SET '$newcharset'") };
         fatal_error "No permission to change charset for '$test_db' database on '$test_dsn' for user '$test_user'" if $failed;
         diag "Changed charset for '$test_db' database to '$newcharset'";
+        $charset = $newcharset;
     }
+}
+
+my $collation = $dbh->selectrow_array('SELECT @@collation_database');
+diag "Database '$test_db' has collation '$collation'";
+
+if ($collation ne "${charset}_unicode_ci") {
+    my $newcollation = "${charset}_unicode_ci";
+    my $failed = not eval { $dbh->do("ALTER DATABASE " . $dbh->quote_identifier($test_db) . " COLLATE '$newcollation'") };
+    fatal_error "No permission to change collation for '$test_db' database on '$test_dsn' for user '$test_user'" if $failed;
+    diag "Changed collation for '$test_db' database to '$newcollation'";
+    $collation = $newcollation;
 }
 
 $dbh->disconnect();

--- a/t/lib.pl
+++ b/t/lib.pl
@@ -32,11 +32,14 @@ sub DbiTestConnect {
     my $err;
     my $dbh = eval { DBI->connect(@_) };
     if ( $dbh ) {
-            my $current_charset = $dbh->selectrow_array('SELECT @@character_set_database');
-            my $expected_charset = $dbh->selectrow_array("SHOW CHARSET LIKE 'utf8mb4'") ? 'utf8mb4' : 'utf8';
-            if ($current_charset ne $expected_charset) {
-                $err = "Database charset is not $expected_charset, but $current_charset";
-            }
+        my ($current_charset, $current_collation) = $dbh->selectrow_array('SELECT @@character_set_database, @@collation_database');
+        my $expected_charset = $dbh->selectrow_array("SHOW CHARSET LIKE 'utf8mb4'") ? 'utf8mb4' : 'utf8';
+        my $expected_collation = "${expected_charset}_unicode_ci";
+        if ($current_charset ne $expected_charset) {
+            $err = "Database charset is not $expected_charset, but $current_charset";
+        } elsif ($current_collation ne $expected_collation) {
+            $err = "Database collation is not $expected_collation, but $current_collation";
+        }
     } else {
         if ( $@ ) {
             $err = $@;


### PR DESCRIPTION
And for utf8 charset use utf8_unicode_ci collation.

Collation utf8mb4_unicode_ci is according to the Unicode 4.0.0 standard.
Collation utf8mb4_general_ci is broken UTF-8 collation. Due to historic
reasons utf8mb4_general_ci is default session collation.

This changes makes DBD::MariaDB more Unicode friendly as it avoids using
broken utf8mb4_general_ci collation.