### PR TITLE
Check that correct number of bind parameters were supplied for $dbh->do() method

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2567,6 +2567,7 @@ IV mariadb_db_do6(SV *dbh, imp_dbh_t *imp_dbh, SV *statement_sv, SV *attribs, I3
   MYSQL_BIND *bind = NULL;
   MYSQL_RES *res;
   STRLEN blen;
+  unsigned long int num_params;
 
   ASYNC_CHECK_RETURN(dbh, -2);
 
@@ -2577,6 +2578,9 @@ IV mariadb_db_do6(SV *dbh, imp_dbh_t *imp_dbh, SV *statement_sv, SV *attribs, I3
   }
 
   SvGETMAGIC(statement_sv);
+
+  if (items < 0)
+    items = 0;
 
   for (i = 0; i < items; i++)
   {
@@ -2707,6 +2711,20 @@ IV mariadb_db_do6(SV *dbh, imp_dbh_t *imp_dbh, SV *statement_sv, SV *attribs, I3
     }
     else
     {
+      num_params = mysql_stmt_param_count(stmt);
+      if (num_params > INT_MAX)
+      {
+        mariadb_dr_do_error(dbh, CR_UNKNOWN_ERROR, "Statement contains too many placeholders", "HY000");
+        mysql_stmt_close(stmt);
+        return -2;
+      }
+      else if ((int)num_params != items)
+      {
+        mariadb_dr_do_error(dbh, ER_WRONG_ARGUMENTS, "Wrong number of bind parameters", "HY000");
+        mysql_stmt_close(stmt);
+        return -2;
+      }
+
       if (items > 0)
       {
         Newz(0, bind, items, MYSQL_BIND);
@@ -2750,6 +2768,18 @@ IV mariadb_db_do6(SV *dbh, imp_dbh_t *imp_dbh, SV *statement_sv, SV *attribs, I3
 
   if (!use_server_side_prepare)
   {
+    num_params = count_params(imp_dbh, aTHX_ statement, statement_len, imp_dbh->bind_comment_placeholders);
+    if (num_params > INT_MAX || num_params == ULONG_MAX)
+    {
+      mariadb_dr_do_error(dbh, CR_UNKNOWN_ERROR, "Statement contains too many placeholders", "HY000");
+      return -2;
+    }
+    else if ((int)num_params != items)
+    {
+      mariadb_dr_do_error(dbh, ER_WRONG_ARGUMENTS, "Wrong number of bind parameters", "HY000");
+      return -2;
+    }
+
     if (items > 0)
     {
       Newz(0, params, items, struct imp_sth_ph_st);

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -58,7 +58,7 @@ typedef struct sql_type_info_s
 
 */
 static unsigned long int
-count_params(imp_xxh_t *imp_xxh, pTHX_ char *statement, STRLEN statement_len, bool bind_comment_placeholders)
+count_params(imp_dbh_t *imp_dbh, pTHX_ char *statement, STRLEN statement_len, bool bind_comment_placeholders)
 {
   bool comment_end = FALSE;
   char* ptr= statement;
@@ -67,8 +67,8 @@ count_params(imp_xxh_t *imp_xxh, pTHX_ char *statement, STRLEN statement_len, bo
   char *end = statement + statement_len;
   char c;
 
-  if (DBIc_DBISTATE(imp_xxh)->debug >= 2)
-    PerlIO_printf(DBIc_LOGPIO(imp_xxh), ">count_params statement %.1000s%s\n", statement, statement_len > 1000 ? "..." : "");
+  if (DBIc_DBISTATE(imp_dbh)->debug >= 2)
+    PerlIO_printf(DBIc_LOGPIO(imp_dbh), ">count_params statement %.1000s%s\n", statement, statement_len > 1000 ? "..." : "");
 
   while (ptr < end)
   {
@@ -94,8 +94,8 @@ count_params(imp_xxh_t *imp_xxh, pTHX_ char *statement, STRLEN statement_len, bo
                   while (ptr < end)
                   {
                       c = *ptr++;
-                      if (DBIc_DBISTATE(imp_xxh)->debug >= 2)
-                          PerlIO_printf(DBIc_LOGPIO(imp_xxh), "%c\n", c);
+                      if (DBIc_DBISTATE(imp_dbh)->debug >= 2)
+                          PerlIO_printf(DBIc_LOGPIO(imp_dbh), "%c\n", c);
                       comment_length++;
                       if (c == '\n')
                       {
@@ -3876,7 +3876,7 @@ mariadb_st_prepare_sv(
   /* Count the number of parameters (driver, vs server-side) */
   if (!imp_sth->use_server_side_prepare)
   {
-    num_params = count_params((imp_xxh_t *)imp_dbh, aTHX_ statement, statement_len,
+    num_params = count_params(imp_dbh, aTHX_ statement, statement_len,
                                             imp_dbh->bind_comment_placeholders);
     if (num_params > INT_MAX || num_params == ULONG_MAX)
     {

--- a/t/43count_params.t
+++ b/t/43count_params.t
@@ -10,7 +10,7 @@ use vars qw($test_dsn $test_user $test_password);
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 
-plan tests => 33*2+1;
+plan tests => 37*2+1;
 
 for my $mariadb_server_prepare (0, 1) {
 
@@ -89,6 +89,14 @@ ok $sth->bind_param(1, 12);
 ok $sth->bind_param(2, "Charles de Batz de Castelmore, comte d'Artagnan");
 
 ok !defined eval { $sth->bind_param(3, 10) };
+
+ok !defined eval { $dbh->do("INSERT INTO dbd_mysql_t43count_params (id, name) VALUES (?, ?)") };
+
+ok !defined eval { $dbh->do("INSERT INTO dbd_mysql_t43count_params (id, name) VALUES (?, ?)", undef) };
+
+ok !defined eval { $dbh->do("INSERT INTO dbd_mysql_t43count_params (id, name) VALUES (?, ?)", undef, 9) };
+
+ok !defined eval { $dbh->do("INSERT INTO dbd_mysql_t43count_params (id, name) VALUES (?, ?)", undef, 10, "Charles de Batz de Castelmore, comte d'Artagnan", 10) };
 
 is_deeply (
     $dbh->selectall_arrayref("SELECT id, name FROM dbd_mysql_t43count_params"),


### PR DESCRIPTION
Same change as in commit 989bdb3cb27ff67806f50ebf76f390ae465fd4dd but this
time for DBI's $dbh->do() method.

When number of bind parameters was less then number of placeholders in
statement then DBD::MariaDB caused SEGFAULT of whole perl process as it
read out-of-bound memory. Check in this change prevents crashing of perl
process and properly propagates DBI error to the caller.