### PR TITLE
Do not call plan in the middle of test t/rt88006-bit-prepare.t

### DIFF
--- a/t/rt88006-bit-prepare.t
+++ b/t/rt88006-bit-prepare.t
@@ -7,15 +7,7 @@ use Test::More;
 use lib 't', '.';
 require 'lib.pl';
 
-for my $scenario (qw(prepare noprepare)) {
-
-my $dbh;
-my $sth;
-
-my $dsn = $test_dsn;
-$dsn .= ';mariadb_server_prepare=1;mariadb_server_prepare_disable_fallback=1' if $scenario eq 'prepare';
-$dbh = DbiTestConnect($dsn, $test_user, $test_password,
-  { RaiseError => 1, AutoCommit => 1});
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, AutoCommit => 1});
 
 if ($dbh->{mariadb_serverversion} < 50008) {
   plan skip_all => "Servers < 5.0.8 do not support b'' syntax";
@@ -28,6 +20,17 @@ if ($dbh->{mariadb_serverversion} < 50026) {
 if ($dbh->{mariadb_clientversion} < 50003) {
   plan skip_all => "Clients < 5.0.3 do not support BIT type";
 }
+
+$dbh->disconnect();
+
+for my $scenario (qw(prepare noprepare)) {
+
+my $sth;
+
+my $dsn = $test_dsn;
+$dsn .= ';mariadb_server_prepare=1;mariadb_server_prepare_disable_fallback=1' if $scenario eq 'prepare';
+$dbh = DBI->connect($dsn, $test_user, $test_password,
+  { RaiseError => 1, AutoCommit => 1});
 
 my $create = <<EOT;
 CREATE TEMPORARY TABLE `dbd_mysql_rt88006_bit_prep` (


### PR DESCRIPTION
DbiTestConnect calls "plan skip_all" when connection to database cannot be
established. And calling "plan" in the middle of test cause TAP errors.