### PR TITLE
Simplify workaround for MySQL clients with broken mysql_insert_id()

### DIFF
--- a/MariaDB.xs
+++ b/MariaDB.xs
@@ -118,31 +118,16 @@ ping(dbh)
     SV* dbh;
   CODE:
     {
-#ifdef HAVE_BROKEN_INSERT_ID_AFTER_PING
-      /*
-       * mysql_insert_id() returns incorrect value after mysql_ping() C function.
-       * As a workaround prior to calling mysql_ping() function we store value
-       * of last insert id. After function finish we restore previous value of
-       * last insert id.
-       */
-      my_ulonglong insertid;
-#endif
       D_imp_dbh(dbh);
       ASYNC_CHECK_XS(dbh);
       if (!imp_dbh->pmysql)
         XSRETURN_NO;
-#ifdef HAVE_BROKEN_INSERT_ID_AFTER_PING
-      insertid = mysql_insert_id(imp_dbh->pmysql);
-#endif
       RETVAL = (mysql_ping(imp_dbh->pmysql) == 0);
       if (!RETVAL)
       {
         if (mariadb_db_reconnect(dbh, NULL))
           RETVAL = (mysql_ping(imp_dbh->pmysql) == 0);
       }
-#ifdef HAVE_BROKEN_INSERT_ID_AFTER_PING
-      imp_dbh->pmysql->insert_id = insertid;
-#endif
     }
   OUTPUT:
     RETVAL

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4106,6 +4106,7 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
 
     if (imp_sth->result == NULL)
     {
+      imp_dbh->insertid = imp_sth->insertid = mysql_insert_id(imp_dbh->pmysql);
       /* No "real" rowset*/
       DBIS->set_attr_k(sth, sv_2mortal(newSVpvs("NUM_OF_FIELDS")), 0,
 			               sv_2mortal(newSViv(0)));

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -323,25 +323,6 @@ PERL_STATIC_INLINE UV SvUV_nomg(pTHX_ SV *sv)
 #endif
 
 /*
- * MySQL 5.7 below 5.7.18 and MySQL 8.0.0 are affected by Bug #78778.
- * mysql_insert_id() is reset to 0 after performing SELECT operation.
- * https://bugs.mysql.com/bug.php?id=78778
- */
-#if !defined(MARIADB_BASE_VERSION) && ((MYSQL_VERSION_ID >= 50700 && MYSQL_VERSION_ID <= 50717) || MYSQL_VERSION_ID == 80000)
-#define HAVE_BROKEN_INSERT_ID_AFTER_SELECT
-#endif
-
-/*
- * MySQL 5.7, MySQL 8.0, MySQL Connector/C 6.1.5 and higher are affected by Bug #89139.
- * mysql_insert_id() is reset to 0 after calling mysql_ping() C function.
- * Once Bug #89139 is fixed we can adjust the upper bound of this check.
- * https://bugs.mysql.com/bug.php?id=89139
- */
-#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 50700 && (MYSQL_VERSION_ID < 60100 || MYSQL_VERSION_ID >= 60105)
-#define HAVE_BROKEN_INSERT_ID_AFTER_PING
-#endif
-
-/*
  * MySQL and MariaDB Embedded are affected by https://jira.mariadb.org/browse/MDEV-16578
  * MariaDB 10.2.2+ prior to 10.2.19 and 10.3.9 and MariaDB Connector/C prior to 3.0.5 are affected by https://jira.mariadb.org/browse/CONC-336
  * MySQL 8.0.4+ is affected too by https://bugs.mysql.com/bug.php?id=93276
@@ -476,6 +457,7 @@ struct imp_dbh_st {
     bool use_server_side_prepare;
     bool disable_fallback_for_server_prepare;
     void* async_query_in_flight;
+    my_ulonglong insertid;
     struct {
 	    unsigned int auto_reconnects_ok;
 	    unsigned int auto_reconnects_failed;

--- a/t/31insertid.t
+++ b/t/31insertid.t
@@ -11,7 +11,7 @@ require "lib.pl";
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
 			    {RaiseError => 1});
 
-plan tests => 3 + 2*30;
+plan tests => 3 + 2*37;
 
 SKIP: {
     skip 'SET @@auto_increment_offset needs MySQL >= 5.0.2', 2 unless $dbh->{mariadb_serverversion} >= 50002;
@@ -78,6 +78,14 @@ is $sth->last_insert_id(), 2, "second insert id == \$sth->last_insert_id()";
 is $dbh->{mariadb_insertid}, 3, "third insert id == $dbh->{mariadb_insertid}";
 is $sth3->last_insert_id(), 3, "third insert id == \$sth3->last_insert_id()";
 is $dbh->last_insert_id(undef, undef, undef, undef), 3, "third insert id == \$dbh->last_insert_id()";
+
+ok $dbh->do($query, undef, "Name 2"), "inserting fourth value via \$dbh->do()";
+is $dbh->{mariadb_insertid}, 4, "fourth insert id == $dbh->{mariadb_insertid}";
+is $dbh->last_insert_id(undef, undef, undef, undef), 4, "fourth insert id == \$dbh->last_insert_id()";
+is $sth->{mariadb_insertid}, 2, "second insert id == \$sth->{mariadb_insertid}";
+is $sth->last_insert_id(), 2, "second insert id == \$sth->last_insert_id()";
+is $sth3->{mariadb_insertid}, 3, "third insert id == \$sth3->{mariadb_insertid}";
+is $sth3->last_insert_id(), 3, "third insert id == \$sth3->last_insert_id()";
 
 ok $sth->finish();
 ok $sth2->finish();


### PR DESCRIPTION
Some MySQL client versions have broken mysql_insert_id() function. Return
value of that function is reset to zero after calling mysql_ping() function
or after issuing SQL query which receive result set.

Seems that MySQL bug #89139 is not going to be fixed, but rather
documentation was changed about this "unexpected" behavior.

So instead of trying to detect which version of MySQL client is broken and
trying to workaround it by updating internal structure, call function
mysql_insert_id() only at time when it returns correct value and then store
it into dbh cache. On subsequent access just read cached value.

With this solution there is no needed to have tons of #ifdefs and cache is
used for all versions of MySQL and MariaDB clients.

See: https://bugs.mysql.com/bug.php?id=89139
See: https://dev.mysql.com/doc/refman/8.0/en/mysql-insert-id.html