### PR TITLE
Fix overflow in attributes and do not export local functions

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2513,6 +2513,9 @@ int mariadb_db_login6_sv(SV *dbh, imp_dbh_t *imp_dbh, SV *dsn, SV *user, SV *pas
 }
 
 
+static my_ulonglong mariadb_st_internal_execute(SV *h, char *sbuf, STRLEN slen, int num_params, imp_sth_ph_t *params, MYSQL_RES **result, MYSQL **svsock, bool use_mysql_use_result);
+static my_ulonglong mariadb_st_internal_execute41(SV *h, char *sbuf, STRLEN slen, bool has_params, MYSQL_RES **result, MYSQL_STMT **stmt_ptr, MYSQL_BIND *bind, MYSQL **svsock, bool *has_been_bound);
+
 /**************************************************************************
  *
  *  Name:    mariadb_db_do6
@@ -4171,7 +4174,7 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
  **************************************************************************/
 
 
-my_ulonglong mariadb_st_internal_execute(
+static my_ulonglong mariadb_st_internal_execute(
                                        SV *h, /* could be sth or dbh */
                                        char *sbuf,
                                        STRLEN slen,
@@ -4312,7 +4315,7 @@ my_ulonglong mariadb_st_internal_execute(
  *
  **************************************************************************/
 
-my_ulonglong mariadb_st_internal_execute41(
+static my_ulonglong mariadb_st_internal_execute41(
                                          SV *h,
                                          char *sbuf,
                                          STRLEN slen,

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3561,9 +3561,9 @@ SV* mariadb_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
     else if (memEQs(key, kl, "mariadb_server_prepare_disable_fallback"))
       result = boolSV(imp_dbh->disable_fallback_for_server_prepare);
     else if (memEQs(key, kl, "mariadb_thread_id"))
-      result = imp_dbh->pmysql ? sv_2mortal(newSViv(mysql_thread_id(imp_dbh->pmysql))) : &PL_sv_undef;
+      result = imp_dbh->pmysql ? sv_2mortal(newSVuv(mysql_thread_id(imp_dbh->pmysql))) : &PL_sv_undef;
     else if (memEQs(key, kl, "mariadb_warning_count"))
-      result = imp_dbh->pmysql ? sv_2mortal(newSViv(mysql_warning_count(imp_dbh->pmysql))) : &PL_sv_undef;
+      result = imp_dbh->pmysql ? sv_2mortal(newSVuv(mysql_warning_count(imp_dbh->pmysql))) : &PL_sv_undef;
     else if (memEQs(key, kl, "mariadb_use_result"))
       result = boolSV(imp_dbh->use_mysql_use_result);
     else

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -617,25 +617,6 @@ SV* mariadb_dr_my_ulonglong2sv(pTHX_ my_ulonglong val);
 
 void    mariadb_dr_do_error (SV* h, unsigned int rc, const char *what, const char *sqlstate);
 
-my_ulonglong mariadb_st_internal_execute(SV *,
-                                       char *,
-                                       STRLEN,
-                                       int,
-                                       imp_sth_ph_t *,
-                                       MYSQL_RES **,
-                                       MYSQL **,
-                                       bool);
-
-my_ulonglong mariadb_st_internal_execute41(SV *,
-                                         char *,
-                                         STRLEN,
-                                         bool,
-                                         MYSQL_RES **,
-                                         MYSQL_STMT **,
-                                         MYSQL_BIND *,
-                                         MYSQL **,
-                                         bool *);
-
 bool mariadb_st_more_results(SV*, imp_sth_t*);
 
 AV* mariadb_db_type_info_all(void);


### PR DESCRIPTION
* Fix overflow in mariadb_thread_id and mariadb_warning_count attributes
* Do not export mariadb_st_internal_execute* functions