### PR TITLE
Fix breakage of Net::SSLeay / OpenSSL library after DBI disconnect

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+1.11 2019-01-02
+ - Fix breakage of Net::SSLeay / OpenSSL library after DBI disconnect
+   (https://github.com/gooddata/DBD-MariaDB/issues/119)
+
 1.10 2018-12-05
  - Fix spelling error (https://github.com/gooddata/DBD-MariaDB/issues/82)
  - Fix MinGW build (https://github.com/gooddata/DBD-MariaDB/issues/91)

--- a/MANIFEST
+++ b/MANIFEST
@@ -84,6 +84,7 @@ t/92ssl_connection.t
 t/92ssl_optional.t
 t/92ssl_backronym_vulnerability.t
 t/92ssl_riddle_vulnerability.t
+t/93net_ssleay.t
 t/99_bug_server_prepare_blob_null.t
 t/cve-2017-3302.t
 t/lib.pl

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -270,6 +270,14 @@ my $have_get_option = check_lib(
   function => 'MYSQL mysql; char buf[1024]; mysql_server_init(-1, 0, 0); mysql_init(&mysql); mysql_get_option(&mysql, 0, &buf); return 0;',
 );
 
+my $have_deinitialize_ssl = check_lib(
+  LIBS => (join ' ', @libdirs, $main_lib),
+  ccflags => $opt->{cflags},
+  ldflags => (join ' ', @libdirs, @libs, @ldflags),
+  header => 'mysql.h',
+  function => 'mariadb_deinitialize_ssl = 0; return 0;',
+);
+
 my $fileName = File::Spec->catfile("t", "MariaDB.mtest");
 (open(FILE, ">$fileName") &&
  (print FILE ("{ local " . Data::Dumper->Dump([$opt], ["opt"]) .
@@ -298,6 +306,7 @@ $cflags .= " -DHAVE_DBI_1_642" if eval { DBI->VERSION(1.642) };
 $cflags .= " -DHAVE_EMBEDDED" if $have_embedded;
 $cflags .= " -DHAVE_GET_CHARSET_NUMBER" if $have_get_charset_number;
 $cflags .= " -DHAVE_GET_OPTION" if $have_get_option;
+$cflags .= " -DHAVE_DEINITIALIZE_SSL" if $have_deinitialize_ssl;
 my %o = ( 'NAME' => 'DBD::MariaDB',
 	  'INC' => $cflags,
 	  'dist'         => { 'SUFFIX'       => ".gz",
@@ -407,6 +416,7 @@ if (eval { ExtUtils::MakeMaker->VERSION(5.43) }) {
       prereqs => {
         test => {
           recommends => {
+            'Net::SSLeay' => 0,
             'Proc::ProcessTable' => 0,
             'TAP::Harness' => '3.31',
             'CPAN::Meta::YAML' => 0,

--- a/MariaDB.xs
+++ b/MariaDB.xs
@@ -63,6 +63,11 @@ BOOT:
   newTypeSub(stash, MYSQL_TYPE_VAR_STRING);
   newTypeSub(stash, MYSQL_TYPE_STRING);
 #undef newTypeSub
+#ifdef HAVE_DEINITIALIZE_SSL
+  /* Do not deinitialize OpenSSL library after mysql_server_end()
+   * See: https://github.com/gooddata/DBD-MariaDB/issues/119 */
+  mariadb_deinitialize_ssl = 0;
+#endif
   mysql_thread_init();
 }
 

--- a/lib/DBD/MariaDB.pm
+++ b/lib/DBD/MariaDB.pm
@@ -10,7 +10,7 @@ use DBI;
 use DynaLoader();
 our @ISA = qw(DynaLoader);
 
-our $VERSION = '1.10';
+our $VERSION = '1.11';
 
 bootstrap DBD::MariaDB $VERSION;
 

--- a/t/93net_ssleay.t
+++ b/t/93net_ssleay.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use DBI;
+use DBD::MariaDB;
+
+BEGIN {
+    plan skip_all => 'Net::SSLeay is required for this test' unless eval { require Net::SSLeay };
+    Net::SSLeay->import();
+}
+
+sub diag_ssl {
+    my $error = Net::SSLeay::ERR_get_error();
+    my $error_string = Net::SSLeay::ERR_error_string($error);
+    diag($error_string);
+    Net::SSLeay::load_error_strings();
+    my $error_string2 = Net::SSLeay::ERR_error_string($error);
+    diag($error_string2);
+}
+
+Net::SSLeay::initialize();
+
+my $ctx_new_sub = Net::SSLeay->can('CTX_tlsv1_2_new') || Net::SSLeay->can('CTX_tlsv1_1_new') || Net::SSLeay->can('CTX_tlsv1_new');
+plan skip_all => 'Net::SSLeay does not provide TLS context' unless defined $ctx_new_sub;
+
+plan tests => 4;
+
+my $ctx1 = $ctx_new_sub->();
+ok($ctx1, 'Net::SSLeay TLS context was created before MariaDB connection') or diag_ssl();
+
+my $dbh = DBI->connect('DBI:MariaDB:', undef, undef, { RaiseError => 0, PrintError => 0 });
+$dbh->disconnect() if defined $dbh;
+$dbh = undef;
+pass('MariaDB connection was successfully created and destroyed');
+
+my $ctx2 = $ctx_new_sub->();
+ok($ctx2, 'Net::SSLeay TLS context was created after MariaDB connection') or diag_ssl();
+
+Net::SSLeay::CTX_free($ctx1);
+Net::SSLeay::CTX_free($ctx2);
+pass('Net::SSLeay TLS contexts were destroyed');


### PR DESCRIPTION
MariaDB deinitialize OpenSSL library in mysql_server_end() function.
Therefore Net::SSLeay stopped working after closing all DBD::MariaDB
handles. For disabling deinitialization of OpenSSL it is needed to set
global variable mariadb_deinitialize_ssl to zero.

Fixes: https://github.com/gooddata/DBD-MariaDB/issues/119