### PR TITLE
Fix compilation on OpenBSD and HP-UX

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -10,6 +10,12 @@
 #include <stddef.h>
 #include <errno.h>
 
+#ifndef _WIN32
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
 /*
  * Warning: Native socket code must be outside of dbdimp.c and dbdimp.h because
  *          perl header files redefine socket function. This file must not


### PR DESCRIPTION
For using select() function on POSIX systems it is needed to include more
header files.

Fixes: 5034cd71c2179fc166bc55fd5633d8a3f02fced2