### PR TITLE
Fix state of $sth->{Active} attribute and usage of $sth->finish() method

### DIFF
--- a/MariaDB.xs
+++ b/MariaDB.xs
@@ -273,8 +273,6 @@ mariadb_async_result(sth)
         if (retval == (my_ulonglong)-1)
             XSRETURN_UNDEF;
 
-        imp_sth->row_num = retval;
-
         if (retval == 0)
             XSRETURN_PV("0E0");
 

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3712,7 +3712,7 @@ AV *mariadb_db_data_sources(SV *dbh, imp_dbh_t *imp_dbh, SV *attr)
   return av;
 }
 
-static bool mariadb_st_free_result_sets(SV *sth, imp_sth_t *imp_sth);
+static bool mariadb_st_free_result_sets(SV *sth, imp_sth_t *imp_sth, bool free_last);
 
 /* 
  **************************************************************************
@@ -3774,7 +3774,6 @@ mariadb_st_prepare_sv(
   imp_sth->use_server_side_prepare = imp_dbh->use_server_side_prepare;
   imp_sth->disable_fallback_for_server_prepare = imp_dbh->disable_fallback_for_server_prepare;
 
-  imp_sth->fetch_done = FALSE;
   imp_sth->done_desc = FALSE;
   imp_sth->result = NULL;
   imp_sth->currow = 0;
@@ -3845,7 +3844,7 @@ mariadb_st_prepare_sv(
      Clean-up previous result set(s) for sth to prevent
      'Commands out of sync' error 
   */
-  if (!mariadb_st_free_result_sets(sth, imp_sth))
+  if (!mariadb_st_free_result_sets(sth, imp_sth, TRUE))
     return 0;
 
   if (imp_sth->use_server_side_prepare)
@@ -3989,11 +3988,12 @@ mariadb_st_prepare_sv(
  *
  * Inputs: sth - Statement handle
  *         imp_sth - driver's private statement handle
+ *         free_last - free also the last result set
  *
  * Returns: TRUE ok
  *          FALSE error; mariadb_dr_do_error will be called
  *************************************************************************/
-static bool mariadb_st_free_result_sets(SV *sth, imp_sth_t *imp_sth)
+static bool mariadb_st_free_result_sets(SV *sth, imp_sth_t *imp_sth, bool free_last)
 {
   dTHX;
   D_imp_dbh_from_sth;
@@ -4031,7 +4031,7 @@ static bool mariadb_st_free_result_sets(SV *sth, imp_sth_t *imp_sth)
         imp_dbh->insertid = imp_sth->insertid = mysql_insert_id(imp_dbh->pmysql);
       }
     }
-    if (imp_sth->result)
+    if (imp_sth->result && (mysql_more_results(imp_dbh->pmysql) || free_last))
     {
       mysql_free_result(imp_sth->result);
       imp_sth->result=NULL;
@@ -4102,6 +4102,8 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
   }
   imp_dbh->async_query_in_flight = NULL;
 
+  DBIc_ACTIVE_off(imp_sth);
+
   if (!imp_dbh->pmysql && !mariadb_db_reconnect(sth, NULL))
   {
     mariadb_dr_do_error(sth, CR_SERVER_GONE_ERROR, "MySQL server has gone away", "HY000");
@@ -4163,9 +4165,6 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
   (void)hv_deletes((HV*)SvRV(sth), "mariadb_type_name", G_DISCARD);
   (void)hv_deletes((HV*)SvRV(sth), "mariadb_warning_count", G_DISCARD);
 
-  if (DBIc_ACTIVE(imp_sth))
-    DBIc_ACTIVE_off(imp_sth);
-
   next_result_return_code= mysql_next_result(imp_dbh->pmysql);
 
   imp_sth->warning_count = mysql_warning_count(imp_dbh->pmysql);
@@ -4210,6 +4209,9 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
       imp_sth->row_num = mysql_affected_rows(imp_dbh->pmysql);
 
       imp_dbh->insertid = imp_sth->insertid = mysql_insert_id(imp_dbh->pmysql);
+
+      if (mysql_more_results(imp_dbh->pmysql))
+        DBIc_ACTIVE_on(imp_sth);
     }
     else
     {
@@ -4221,7 +4223,8 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
           sv_2mortal(newSVuv(mysql_num_fields(imp_sth->result)))
       );
 
-      DBIc_ACTIVE_on(imp_sth);
+      if (imp_sth->row_num)
+        DBIc_ACTIVE_on(imp_sth);
     }
 
     if (imp_sth->is_async && mysql_more_results(imp_dbh->pmysql))
@@ -4619,7 +4622,7 @@ IV mariadb_st_execute_iv(SV* sth, imp_sth_t* imp_sth)
      Clean-up previous result set(s) for sth to prevent
      'Commands out of sync' error 
   */
-  if (!mariadb_st_free_result_sets(sth, imp_sth))
+  if (!mariadb_st_free_result_sets(sth, imp_sth, TRUE))
     return -2;
 
   if (use_server_side_prepare)
@@ -4694,10 +4697,10 @@ IV mariadb_st_execute_iv(SV* sth, imp_sth_t* imp_sth)
       /** Store the result in the current statement handle */
       num_fields = mysql_num_fields(imp_sth->result);
       DBIc_NUM_FIELDS(imp_sth) = (num_fields <= INT_MAX) ? num_fields : INT_MAX;
-      DBIc_ACTIVE_on(imp_sth);
+      if (imp_sth->row_num)
+        DBIc_ACTIVE_on(imp_sth);
       if (!use_server_side_prepare)
         imp_sth->done_desc = FALSE;
-      imp_sth->fetch_done = FALSE;
     }
   }
 
@@ -4740,6 +4743,9 @@ static int mariadb_st_describe(SV* sth, imp_sth_t* imp_sth)
   if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
     PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t--> mariadb_st_describe\n");
 
+  if (imp_sth->done_desc)
+    return 1;
+
   if (imp_sth->use_server_side_prepare)
   {
     int i;
@@ -4751,9 +4757,6 @@ static int mariadb_st_describe(SV* sth, imp_sth_t* imp_sth)
     if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
       PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tmariadb_st_describe() num_fields %d\n",
                     num_fields);
-
-    if (imp_sth->done_desc)
-      return 1;
 
     if (num_fields <= 0 || !imp_sth->result)
     {
@@ -4916,30 +4919,22 @@ mariadb_st_fetch(SV *sth, imp_sth_t* imp_sth)
     return Nullav;
   }
 
-  if(imp_dbh->async_query_in_flight) {
-      if (mariadb_db_async_result(sth, &imp_sth->result) == (my_ulonglong)-1)
-        return Nullav;
-  }
-
-  if (imp_sth->use_server_side_prepare)
+  if (imp_dbh->async_query_in_flight)
   {
-    if (!DBIc_ACTIVE(imp_sth) )
+    if (!DBIc_ACTIVE(imp_sth))
+      return Nullav;
+    if (mariadb_db_async_result(sth, &imp_sth->result) == (my_ulonglong)-1)
+      return Nullav;
+  }
+  else
+  {
+    if (!imp_sth->result)
     {
-      mariadb_dr_do_error(sth, CR_UNKNOWN_ERROR, "no statement executing", "HY000");
+      mariadb_dr_do_error(sth, CR_UNKNOWN_ERROR, "fetch() without execute()", "HY000");
       return Nullav;
     }
-
-    if (imp_sth->fetch_done)
-    {
-      mariadb_dr_do_error(sth, CR_UNKNOWN_ERROR, "fetch() but fetch already done", "HY000");
+    if (!DBIc_ACTIVE(imp_sth))
       return Nullav;
-    }
-
-    if (!imp_sth->done_desc)
-    {
-      if (!mariadb_st_describe(sth, imp_sth))
-        return Nullav;
-    }
   }
 
   ChopBlanks = DBIc_is(imp_sth, DBIcf_ChopBlanks) ? TRUE : FALSE;
@@ -4949,19 +4944,16 @@ mariadb_st_fetch(SV *sth, imp_sth_t* imp_sth)
                   "\t\tmariadb_st_fetch for %p, chopblanks %d\n",
                   sth, ChopBlanks ? 1 : 0);
 
-  if (!imp_sth->result)
-  {
-    mariadb_dr_do_error(sth, CR_UNKNOWN_ERROR, "fetch() without execute()", "HY000");
-    return Nullav;
-  }
-
   /* fix from 2.9008 */
   imp_dbh->pmysql->net.last_errno = 0;
 
   if (imp_sth->use_server_side_prepare)
   {
+    if (!mariadb_st_describe(sth, imp_sth))
+      return Nullav;
+
     if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
-      PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tmariadb_st_fetch calling mysql_fetch\n");
+      PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tmariadb_st_fetch calling mysql_stmt_fetch\n");
 
     if ((rc= mysql_stmt_fetch(imp_sth->stmt)))
     {
@@ -4975,7 +4967,6 @@ mariadb_st_fetch(SV *sth, imp_sth_t* imp_sth)
 
       if (rc == MYSQL_NO_DATA)
       {
-        imp_sth->fetch_done = TRUE;
         if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
           PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tmariadb_st_fetch no data\n");
       }
@@ -4986,11 +4977,16 @@ mariadb_st_fetch(SV *sth, imp_sth_t* imp_sth)
                  mysql_stmt_sqlstate(imp_sth->stmt));
       }
 
+      DBIc_ACTIVE_off(imp_sth);
+
       return Nullav;
     }
 
 process:
     imp_sth->currow++;
+
+    if (imp_sth->currow >= imp_sth->row_num)
+      DBIc_ACTIVE_off(imp_sth);
 
     av= DBIc_DBISTATE(imp_sth)->get_fbav(imp_sth);
     num_fields=mysql_stmt_field_count(imp_sth->stmt);
@@ -5245,8 +5241,8 @@ process:
                     SVfARG(sv_2mortal(my_ulonglong2sv(mysql_num_rows(imp_sth->result)))));
       PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\tmysql_affected_rows=%" SVf "\n",
                     SVfARG(sv_2mortal(my_ulonglong2sv(mysql_affected_rows(imp_dbh->pmysql)))));
-      PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\tmariadb_st_fetch for %p, currow= %d\n",
-                    sth,imp_sth->currow);
+      PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\tmariadb_st_fetch for %p, currow=%" SVf "\n",
+                    sth, SVfARG(sv_2mortal(my_ulonglong2sv(imp_sth->currow))));
     }
 
     if (!(cols= mysql_fetch_row(imp_sth->result)))
@@ -5259,8 +5255,13 @@ process:
         mariadb_dr_do_error(sth, mysql_errno(imp_dbh->pmysql),
                  mysql_error(imp_dbh->pmysql),
                  mysql_sqlstate(imp_dbh->pmysql));
+      if (!mysql_more_results(imp_dbh->pmysql))
+        DBIc_ACTIVE_off(imp_sth);
       return Nullav;
     }
+
+    if (imp_sth->currow >= imp_sth->row_num && !mysql_more_results(imp_dbh->pmysql))
+      DBIc_ACTIVE_off(imp_sth);
 
     num_fields= mysql_num_fields(imp_sth->result);
     fields= mysql_fetch_fields(imp_sth->result);
@@ -5393,32 +5394,22 @@ int mariadb_st_finish(SV* sth, imp_sth_t* imp_sth) {
   }
 
   if (imp_sth->use_server_side_prepare && imp_sth->stmt)
-  {
-    /*
-      We have to fetch all data from stmt
-      There is may be useful for 2 cases:
-      1. st_finish when we have undef statement
-      2. call st_execute again when we have some unfetched data in stmt
-     */
-    if (DBIc_ACTIVE(imp_sth) && mariadb_st_describe(sth, imp_sth) && !imp_sth->fetch_done)
-      mysql_stmt_free_result(imp_sth->stmt);
-  }
+    mysql_stmt_free_result(imp_sth->stmt);
+
+  /*
+    Clean-up previous result set(s) for sth to prevent
+    'Commands out of sync' error
+  */
+  if (!mariadb_st_free_result_sets(sth, imp_sth, FALSE))
+    return 0;
 
   /*
     Cancel further fetches from this cursor.
     We don't close the cursor till DESTROY.
     The application may re execute it.
   */
-  if (imp_sth && DBIc_ACTIVE(imp_sth))
-  {
-    /*
-      Clean-up previous result set(s) for sth to prevent
-      'Commands out of sync' error
-    */
-    if (!mariadb_st_free_result_sets(sth, imp_sth))
-      return 0;
-  }
   DBIc_ACTIVE_off(imp_sth);
+
   if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
   {
     PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\n<-- mariadb_st_finish\n");
@@ -5449,6 +5440,16 @@ void mariadb_st_destroy(SV *sth, imp_sth_t *imp_sth) {
   imp_sth_fbh_t *fbh;
   int num_params;
   int num_fields;
+
+  if (!PL_dirty)
+  {
+    /* During global destruction, DBI objects are destroyed in random order
+     * and therefore imp_dbh may be already freed. So do not access it. */
+    mariadb_st_finish(sth, imp_sth);
+    mariadb_st_free_result_sets(sth, imp_sth, TRUE);
+  }
+
+  DBIc_ACTIVE_off(imp_sth);
 
   if (imp_sth->statement)
     Safefree(imp_sth->statement);
@@ -5485,8 +5486,6 @@ void mariadb_st_destroy(SV *sth, imp_sth_t *imp_sth) {
     mysql_stmt_close(imp_sth->stmt);
     imp_sth->stmt= NULL;
   }
-
-  /* mariadb_st_finish has already been called by .xs code if needed.	*/
 
   /* Free values allocated by mariadb_st_bind_ph */
   if (imp_sth->params)
@@ -6520,6 +6519,12 @@ my_ulonglong mariadb_db_async_result(SV* h, MYSQL_RES** resp)
   }
   dbh->async_query_in_flight = NULL;
 
+  if (htype == DBIt_ST)
+  {
+    D_imp_sth(h);
+    DBIc_ACTIVE_off(imp_sth);
+  }
+
   svsock= dbh->pmysql;
   if (!svsock)
   {
@@ -6561,13 +6566,13 @@ my_ulonglong mariadb_db_async_result(SV* h, MYSQL_RES** resp)
 
         if(! *resp) {
           imp_sth->insertid = dbh->insertid;
-          if(! mysql_more_results(svsock))
-            DBIc_ACTIVE_off(imp_sth);
+          if (mysql_more_results(svsock))
+            DBIc_ACTIVE_on(imp_sth);
         } else {
           num_fields = mysql_num_fields(imp_sth->result);
           DBIc_NUM_FIELDS(imp_sth) = (num_fields <= INT_MAX) ? num_fields : INT_MAX;
-          imp_sth->done_desc = FALSE;
-          imp_sth->fetch_done = FALSE;
+          if (imp_sth->row_num)
+            DBIc_ACTIVE_on(imp_sth);
         }
       imp_sth->warning_count = mysql_warning_count(imp_dbh->pmysql);
     }

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4899,7 +4899,10 @@ mariadb_st_fetch(SV *sth, imp_sth_t* imp_sth)
     PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t-> mariadb_st_fetch\n");
 
   if (!imp_dbh->pmysql)
+  {
+    mariadb_dr_do_error(sth, CR_SERVER_GONE_ERROR, "MySQL server has gone away", "HY000");
     return Nullav;
+  }
 
   if(imp_dbh->async_query_in_flight) {
       if (mariadb_db_async_result(sth, &imp_sth->result) == (my_ulonglong)-1)
@@ -6507,7 +6510,11 @@ my_ulonglong mariadb_db_async_result(SV* h, MYSQL_RES** resp)
 
   svsock= dbh->pmysql;
   if (!svsock)
+  {
+    mariadb_dr_do_error(h, CR_SERVER_GONE_ERROR, "MySQL server has gone away", "HY000");
     return -1;
+  }
+
   if (!mysql_read_query_result(svsock))
   {
     *resp= mysql_store_result(svsock);

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3778,6 +3778,7 @@ mariadb_st_prepare_sv(
   imp_sth->done_desc = FALSE;
   imp_sth->result = NULL;
   imp_sth->currow = 0;
+  imp_sth->row_num = 0;
 
   if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
     PerlIO_printf(DBIc_LOGPIO(imp_xxh),
@@ -4127,6 +4128,9 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
     imp_sth->result= NULL;
   }
 
+  imp_sth->currow = 0;
+  imp_sth->row_num = 0;
+
   if (DBIc_ACTIVE(imp_sth))
     DBIc_ACTIVE_off(imp_sth);
 
@@ -4169,10 +4173,10 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
       return FALSE;
     }
 
-    imp_sth->row_num= mysql_affected_rows(imp_dbh->pmysql);
-
     if (imp_sth->result == NULL)
     {
+      imp_sth->row_num = mysql_affected_rows(imp_dbh->pmysql);
+
       imp_dbh->insertid = imp_sth->insertid = mysql_insert_id(imp_dbh->pmysql);
       /* No "real" rowset*/
       DBIS->set_attr_k(sth, sv_2mortal(newSVpvs("NUM_OF_FIELDS")), 0,
@@ -4182,8 +4186,7 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
     else
     {
       /* We have a new rowset */
-      imp_sth->currow=0;
-
+      imp_sth->row_num = mysql_num_rows(imp_sth->result);
 
       /* delete cached handle attributes */
       /* XXX should be driven by a list to ease maintenance */

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -6539,6 +6539,8 @@ my_ulonglong mariadb_db_async_result(SV* h, MYSQL_RES** resp)
       D_imp_sth(h);
       D_imp_dbh_from_sth;
 
+      imp_sth->row_num = retval;
+
         if(! *resp) {
           imp_sth->insertid = dbh->insertid;
           if(! mysql_more_results(svsock))

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -6530,14 +6530,13 @@ my_ulonglong mariadb_db_async_result(SV* h, MYSQL_RES** resp)
     /* Some MySQL client versions return correct value from mysql_insert_id()
      * function only after non-SELECT operation. So store insert id into dbh
      * cache and later read it only from cache. */
-    if (retval != (my_ulonglong)-1 && !*resp)
+    if (!*resp)
       dbh->insertid = mysql_insert_id(svsock);
 
     if(htype == DBIt_ST) {
       D_imp_sth(h);
       D_imp_dbh_from_sth;
 
-      if (retval != (my_ulonglong)-1) {
         if(! *resp) {
           imp_sth->insertid = dbh->insertid;
           if(! mysql_more_results(svsock))
@@ -6548,7 +6547,6 @@ my_ulonglong mariadb_db_async_result(SV* h, MYSQL_RES** resp)
           imp_sth->done_desc = FALSE;
           imp_sth->fetch_done = FALSE;
         }
-      }
       imp_sth->warning_count = mysql_warning_count(imp_dbh->pmysql);
     }
   } else {

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -6519,13 +6519,8 @@ my_ulonglong mariadb_db_async_result(SV* h, MYSQL_RES** resp)
     }
     if (!*resp)
       retval= mysql_affected_rows(svsock);
-    else {
+    else
       retval= mysql_num_rows(*resp);
-      if(resp == &_res) {
-        mysql_free_result(*resp);
-        *resp= NULL;
-      }
-    }
 
     /* Some MySQL client versions return correct value from mysql_insert_id()
      * function only after non-SELECT operation. So store insert id into dbh
@@ -6548,6 +6543,12 @@ my_ulonglong mariadb_db_async_result(SV* h, MYSQL_RES** resp)
           imp_sth->fetch_done = FALSE;
         }
       imp_sth->warning_count = mysql_warning_count(imp_dbh->pmysql);
+    }
+
+    if (*resp && resp == &_res)
+    {
+      mysql_free_result(*resp);
+      *resp = NULL;
     }
   } else {
      mariadb_dr_do_error(h, mysql_errno(svsock), mysql_error(svsock),

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4960,8 +4960,6 @@ mariadb_st_fetch(SV *sth, imp_sth_t* imp_sth)
 
       if (rc == MYSQL_NO_DATA)
       {
-        /* Update row_num to affected_rows value */
-        imp_sth->row_num= mysql_stmt_affected_rows(imp_sth->stmt);
         imp_sth->fetch_done = TRUE;
         if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
           PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t\tmariadb_st_fetch no data\n");

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -553,8 +553,7 @@ struct imp_sth_st {
     bool disable_fallback_for_server_prepare;
 
     MYSQL_RES* result;       /* result                                 */
-    int currow;           /* number of current row                  */
-    bool fetch_done;      /* mark that fetch done                   */
+    my_ulonglong currow;  /* number of current row                  */
     my_ulonglong row_num;         /* total number of rows                   */
 
     bool  done_desc;      /* have we described this sth yet ?	    */

--- a/lib/DBD/MariaDB.pod
+++ b/lib/DBD/MariaDB.pod
@@ -19,7 +19,6 @@ DBD::MariaDB - MariaDB and MySQL driver for the Perl5 Database Interface (DBI)
   while (my $ref = $sth->fetchrow_hashref()) {
       print "Found a row: id = $ref->{'id'}, fn = $ref->{'first_name'}\n";
   }
-  $sth->finish();
 
 =head1 EXAMPLE
 
@@ -55,7 +54,6 @@ DBD::MariaDB - MariaDB and MySQL driver for the Perl5 Database Interface (DBI)
   while (my $ref = $sth->fetchrow_hashref()) {
       print "Found a row: id = $ref->{'id'}, name = $ref->{'name'}\n";
   }
-  $sth->finish();
 
   # Disconnect from the database.
   $dbh->disconnect();

--- a/t/25lockunlock.t
+++ b/t/25lockunlock.t
@@ -40,7 +40,6 @@ my ($row, $errstr);
 $errstr= '';
 $row = $sth->fetchrow_arrayref;
 $errstr= $sth->errstr;
-$sth->finish;
 ok !defined($row), "Fetch should have failed";
 ok !defined($errstr), "Fetch should have failed";
 

--- a/t/30insertfetch.t
+++ b/t/30insertfetch.t
@@ -40,8 +40,6 @@ ok($sth->execute());
 
 ok(not $sth->fetchrow_arrayref());
 
-ok($sth->finish());
-
 ok($dbh->disconnect());
 
 done_testing;

--- a/t/31insertid.t
+++ b/t/31insertid.t
@@ -11,7 +11,7 @@ require "lib.pl";
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                          { RaiseError => 1, PrintError => 0 });
 
-plan tests => 3 + 2*37;
+plan tests => 3 + 2*35;
 
 SKIP: {
     skip 'SET @@auto_increment_offset needs MySQL >= 5.0.2', 2 unless $dbh->{mariadb_serverversion} >= 50002;
@@ -86,9 +86,6 @@ is $sth->{mariadb_insertid}, 2, "second insert id == \$sth->{mariadb_insertid}";
 is $sth->last_insert_id(), 2, "second insert id == \$sth->last_insert_id()";
 is $sth3->{mariadb_insertid}, 3, "third insert id == \$sth3->{mariadb_insertid}";
 is $sth3->last_insert_id(), 3, "third insert id == \$sth3->last_insert_id()";
-
-ok $sth->finish();
-ok $sth2->finish();
 
 ok $dbh->do('DROP TEMPORARY TABLE dbd_mysql_t31');
 

--- a/t/32insert_error.t
+++ b/t/32insert_error.t
@@ -11,7 +11,7 @@ use vars qw($test_dsn $test_user $test_password);
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
   { RaiseError => 1, PrintError => 0 });
 
-plan tests => 9;
+plan tests => 8;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t32");
 
@@ -32,8 +32,6 @@ my $failed = not eval {$sth->execute(1, "Jochen")};
 ok $failed, 'fails with duplicate entry';
 
 ok $sth->execute(2, "Jochen");
-
-ok $sth->finish;
 
 ok $dbh->do("DROP TABLE dbd_mysql_t32");
 

--- a/t/35limit.t
+++ b/t/35limit.t
@@ -14,7 +14,7 @@ require 'lib.pl';
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
-plan tests => 111;
+plan tests => 110;
 
 ok(defined $dbh, "Connected to database");
 
@@ -43,8 +43,6 @@ ok( (defined($array_ref = $sth->fetchall_arrayref) &&
   (!defined($errstr = $sth->errstr) || $sth->errstr eq '')));
 
 ok(@$array_ref == 50);
-
-ok($sth->finish);
 
 ok($dbh->do("DROP TABLE dbd_mysql_t35"));
 

--- a/t/35prepare.t
+++ b/t/35prepare.t
@@ -13,7 +13,7 @@ use vars qw($test_dsn $test_user $test_password);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
     { RaiseError => 1, PrintError => 0 });
 
-plan tests => 50;
+plan tests => 49;
 
 ok(defined $dbh, "Connected to database");
 
@@ -94,7 +94,6 @@ ok($sth= $dbh->prepare("SELECT 1"), "Prepare - Testing bug #20153");
 ok($sth->execute(), "Execute - Testing bug #20153");
 ok($sth->fetchrow_arrayref(), "Fetch - Testing bug #20153");
 ok(!($sth->fetchrow_arrayref()),"Not Fetch - Testing bug #20153");
-ok($sth->finish);
 
 # Install a handler so that a warning about unfreed resources gets caught
 $SIG{__WARN__} = sub { die @_ };

--- a/t/35prepare.t
+++ b/t/35prepare.t
@@ -13,7 +13,7 @@ use vars qw($test_dsn $test_user $test_password);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
     { RaiseError => 1, PrintError => 0 });
 
-plan tests => 49;
+plan tests => 47;
 
 ok(defined $dbh, "Connected to database");
 
@@ -45,8 +45,6 @@ ok(($rows = $sth->execute()), "Inserting second row");
 
 ok($rows == 1, "One row should have been inserted");
 
-ok($sth->finish, "Finishing up with statement handle");
-
 ok($sth= $dbh->prepare("SELECT id, name FROM dbd_mysql_t35prepare WHERE id = 1"),
   "Testing prepare of query");
 
@@ -68,8 +66,6 @@ for (my $i = 0 ; $i < 10; $i++)
   ok($rows= $sth->execute($i, $random_chars), "Testing insert row");
   ok($rows= 1, "Should have inserted one row");
 }
-
-ok($sth->finish, "Testing closing of statement handle");
 
 ok($sth= $dbh->prepare("SELECT * FROM dbd_mysql_t35prepare WHERE id = ? OR id = ?"),
   "Testing prepare of query with placeholders");

--- a/t/40bindparam.t
+++ b/t/40bindparam.t
@@ -10,7 +10,7 @@ use vars qw($test_dsn $test_user $test_password);
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0 });
 
-plan tests => 41;
+plan tests => 40;
 
 ok ($dbh->do("DROP TABLE IF EXISTS dbd_mysql_t40bindparam"));
 
@@ -108,7 +108,5 @@ is $id, 7, '$id set to 7';
 cmp_ok $name, 'eq', '?', "\$name set to '?'";
 
 ok ($dbh->do("DROP TABLE dbd_mysql_t40bindparam"));
-
-ok $sth->finish;
 
 ok $dbh->disconnect;

--- a/t/40bindparam2.t
+++ b/t/40bindparam2.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
   { RaiseError => 1, PrintError => 0 });
 
-plan tests => 14;
+plan tests => 13;
 
 SKIP: {
     skip 'SET @@auto_increment_offset needs MySQL >= 5.0.2', 2 unless $dbh->{mariadb_serverversion} >= 50002;
@@ -40,8 +40,6 @@ ok ($sth->bind_param(1, undef));
 ok ($sth->bind_param(2, 1, DBI::SQL_INTEGER()));
 
 ok ($sth->execute());
-
-ok ($sth->finish());
 
 ok ($rows = $dbh->selectall_arrayref("SELECT * FROM dbd_mysql_t40bindparam2"));
 

--- a/t/40bit.t
+++ b/t/40bit.t
@@ -14,7 +14,7 @@ if ($dbh->{mariadb_serverversion} < 50008) {
     plan skip_all => "Servers < 5.0.8 do not support b'' syntax";
 }
 
-plan tests => 15;
+plan tests => 14;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_b1"), "Drop table if exists dbd_mysql_b1";
 
@@ -35,8 +35,6 @@ ok defined($result), "result returned defined";
 is $result->[0][0], 11111111, "should be 11111111";
 is $result->[1][0], 1010, "should be 1010";
 is $result->[2][0], 101, "should be 101";
-
-ok ($sth->finish);
 
 ok $dbh->do("DROP TABLE dbd_mysql_b1"), "Drop table dbd_mysql_b1";
 

--- a/t/40blobs.t
+++ b/t/40blobs.t
@@ -24,7 +24,7 @@ sub ShowBlob($) {
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
   { RaiseError => 1, PrintError => 0 });
 
-plan tests => 14;
+plan tests => 13;
 
 my $size= 128;
 
@@ -69,8 +69,6 @@ is $$row[0], 1, 'id set to 1';
 cmp_ok byte_string($$row[1]), 'eq', byte_string($blob), 'blob set equal to blob returned';
 
 ShowBlob($blob), ShowBlob(defined($$row[1]) ? $$row[1] : "");
-
-ok ($sth->finish);
 
 ok $dbh->do("DROP TABLE dbd_mysql_t40blobs"), "Drop table dbd_mysql_t40blobs";
 

--- a/t/40nulls.t
+++ b/t/40nulls.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 my ($dbh, $sth);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
-plan tests => 10;
+plan tests => 9;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t40nulls"), "DROP TABLE IF EXISTS dbd_mysql_t40nulls";
 
@@ -33,8 +33,6 @@ ok (my $aref = $sth->fetchrow_arrayref);
 ok !defined($$aref[0]);
 
 ok defined($$aref[1]);
-
-ok $sth->finish;
 
 ok $dbh->do("DROP TABLE dbd_mysql_t40nulls");
 

--- a/t/40nulls_prepare.t
+++ b/t/40nulls_prepare.t
@@ -60,9 +60,6 @@ is_deeply($sth_lookup->fetchrow_arrayref(), [42, 102, undef, 10004]);
 ok($sth_lookup->execute(43), "Query for record of id = 43");
 is_deeply($sth_lookup->fetchrow_arrayref(), [43, 2002, 20003, 200004]);
 
-ok($sth_insert->finish());
-ok($sth_lookup->finish());
-
 ok $dbh->do("DROP TABLE dbd_mysql_t40nullsprepare");
 
 ok($dbh->disconnect(), "Testing disconnect");

--- a/t/40numrows.t
+++ b/t/40numrows.t
@@ -10,18 +10,20 @@ require 'lib.pl';
 my ($dbh, $sth, $aref);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
-plan tests => 31;
+plan tests => 2*33 + 1;
 
-ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t40numrows");
+for my $mariadb_server_prepare (0, 1) {
+
+$dbh->{mariadb_server_prepare} = $mariadb_server_prepare;
 
 my $create= <<EOT;
-CREATE TABLE dbd_mysql_t40numrows (
+CREATE TEMPORARY TABLE dbd_mysql_t40numrows (
   id INT(4) NOT NULL DEFAULT 0,
   name varchar(64) NOT NULL DEFAULT ''
 )
 EOT
 
-ok $dbh->do($create), "CREATE TABLE dbd_mysql_t40numrows";
+ok $dbh->do($create), "create table dbd_mysql_t40numrows";
 
 ok $dbh->do("INSERT INTO dbd_mysql_t40numrows VALUES( 1, 'Alligator Descartes' )"), 'inserting first row';
 
@@ -29,11 +31,13 @@ ok ($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t40numrows WHERE id = 1"));
 
 ok $sth->execute;
 
-is $sth->rows, 1, '\$sth->rows should be 1';
+is $sth->rows, 1, '$sth->rows should be 1';
 
 ok ($aref= $sth->fetchall_arrayref);
 
 is scalar @$aref, 1, 'Verified rows should be 1';
+
+is $sth->rows, 1, '$sth->rows still should be 1';
 
 ok $sth->finish;
 
@@ -43,11 +47,13 @@ ok ($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t40numrows WHERE id >= 1"));
 
 ok $sth->execute;
 
-is $sth->rows, 2, '\$sth->rows should be 2';
+is $sth->rows, 2, '$sth->rows should be 2';
 
 ok ($aref= $sth->fetchall_arrayref);
 
 is scalar @$aref, 2, 'Verified rows should be 2';
+
+is $sth->rows, 2, '$sth->rows still should be 2';
 
 ok $sth->finish;
 
@@ -63,6 +69,8 @@ ok ($aref= $sth->fetchall_arrayref);
 
 is scalar @$aref, 2, 'Verified rows should be 2';
 
+is $sth->rows, 2, 'rows still should be 2';
+
 ok $sth->finish;
 
 ok ($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t40numrows"));
@@ -75,8 +83,12 @@ ok ($aref= $sth->fetchall_arrayref);
 
 is scalar @$aref, 3, 'Verified rows should be 3';
 
+is $sth->rows, 3, 'rows still should be 3';
+
 ok $sth->finish;
 
-ok $dbh->do("DROP TABLE dbd_mysql_t40numrows"), "drop table dbd_mysql_t40numrows";
+ok $dbh->do("DROP TEMPORARY TABLE dbd_mysql_t40numrows"), "drop table dbd_mysql_t40numrows";
+
+}
 
 ok $dbh->disconnect;

--- a/t/40numrows.t
+++ b/t/40numrows.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 my ($dbh, $sth, $aref);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
-plan tests => 2*33 + 1;
+plan tests => 2*32 + 1;
 
 for my $mariadb_server_prepare (0, 1) {
 
@@ -84,8 +84,6 @@ ok ($aref= $sth->fetchall_arrayref);
 is scalar @$aref, 3, 'Verified rows should be 3';
 
 is $sth->rows, 3, 'rows still should be 3';
-
-ok $sth->finish;
 
 ok $dbh->do("DROP TEMPORARY TABLE dbd_mysql_t40numrows"), "drop table dbd_mysql_t40numrows";
 

--- a/t/40numrows.t
+++ b/t/40numrows.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 my ($dbh, $sth, $aref);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
-plan tests => 2*32 + 1;
+plan tests => 2*29 + 1;
 
 for my $mariadb_server_prepare (0, 1) {
 
@@ -39,8 +39,6 @@ is scalar @$aref, 1, 'Verified rows should be 1';
 
 is $sth->rows, 1, '$sth->rows still should be 1';
 
-ok $sth->finish;
-
 ok $dbh->do("INSERT INTO dbd_mysql_t40numrows VALUES( 2, 'Jochen Wiedmann' )"), 'inserting second row';
 
 ok ($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t40numrows WHERE id >= 1"));
@@ -55,8 +53,6 @@ is scalar @$aref, 2, 'Verified rows should be 2';
 
 is $sth->rows, 2, '$sth->rows still should be 2';
 
-ok $sth->finish;
-
 ok $dbh->do("INSERT INTO dbd_mysql_t40numrows VALUES(3, 'Tim Bunce')"), "inserting third row";
 
 ok ($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t40numrows WHERE id >= 2"));
@@ -70,8 +66,6 @@ ok ($aref= $sth->fetchall_arrayref);
 is scalar @$aref, 2, 'Verified rows should be 2';
 
 is $sth->rows, 2, 'rows still should be 2';
-
-ok $sth->finish;
 
 ok ($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t40numrows"));
 

--- a/t/40server_prepare.t
+++ b/t/40server_prepare.t
@@ -14,7 +14,7 @@ $test_dsn.= ";mariadb_server_prepare=1;mariadb_server_prepare_disable_fallback=1
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 
-plan tests => 31;
+plan tests => 29;
 
 ok(defined $dbh, "connecting");
 
@@ -36,8 +36,6 @@ ok ($sth->bind_param(1, 1), "binding parameter");
 ok ($sth->execute(), "fetching data");
 
 is_deeply($sth->fetchall_arrayref({}), [ { 'num' => '3' } ]);
-
-ok ($sth->finish);
 
 ok ($dbh->do(qq{DROP TABLE dbd_mysql_t40serverprepare1}), "cleaning up");
 
@@ -85,7 +83,6 @@ $dbh->{mariadb_server_prepare_disable_fallback} = 0;
 my $sth4;
 ok($sth4 = $dbh->prepare("USE " . $dbh->quote_identifier($test_db)), 'USE is supported with mariadb_server_prepare_disable_fallback=0');
 ok($sth4->execute());
-ok($sth4->finish());
 
 ok ($dbh->do(qq{DROP TABLE t3}), "cleaning up");
 

--- a/t/40server_prepare_crash.t
+++ b/t/40server_prepare_crash.t
@@ -10,7 +10,7 @@ require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1, AutoCommit => 0, mariadb_server_prepare => 1, mariadb_server_prepare_disable_fallback => 1 });
 
-plan tests => 44;
+plan tests => 43;
 
 my $sth;
 
@@ -25,13 +25,13 @@ ok $sth->execute(3, "x" x 1000);
 ok $sth->execute(4, "x" x 10000);
 ok $sth->execute(5, "x" x 100000);
 ok $sth->execute(6, "x" x 1000000);
-ok $sth->finish();
 
 ok $sth = $dbh->prepare("SELECT * FROM t WHERE i=? AND n=?");
 
 ok $sth->bind_param(2, "x" x 1000000);
 ok $sth->bind_param(1, "abcx", 12);
 ok $sth->execute();
+ok $sth->finish();
 
 ok $sth->bind_param(2, "a" x 1000000);
 ok $sth->bind_param(1, 1, 3);
@@ -72,8 +72,6 @@ ok $sth->fetchrow_arrayref();
 ok $sth->execute(6);
 $test = map { $_ } 'hijk' x 10000000; # try to reuse of released memory
 ok $sth->fetchrow_arrayref();
-
-ok $sth->finish();
 
 ok $dbh->do("SELECT 1 FROM t WHERE i = ?" . (" OR i = ?" x 10000), {}, (1) x (10001));
 

--- a/t/40sth_attr.t
+++ b/t/40sth_attr.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More;
 use DBI;
+use DBD::MariaDB;
 
 use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
@@ -10,21 +11,117 @@ require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1 });
 
-plan tests => 11;
+plan tests => 90;
 
 ok($dbh->do("CREATE TEMPORARY TABLE t(id INT)"));
 ok($dbh->do("INSERT INTO t(id) VALUES(1)"));
 
-my $sth = $dbh->prepare("SELECT * FROM t");
-ok($sth->execute());
-ok($sth->fetchall_arrayref());
-is_deeply($sth->{NAME}, ["id"]);
-ok($sth->finish());
+my $sth1 = $dbh->prepare("SELECT * FROM t");
+ok(!$sth1->{Active});
+ok($sth1->execute());
+ok($sth1->{Active});
+is_deeply($sth1->{NAME}, ["id"]);
+is_deeply($sth1->fetchall_arrayref(), [ [ 1 ] ]);
+ok(!$sth1->{Active});
+is_deeply($sth1->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG ]);
 
 my $sth2 = $dbh->prepare("SELECT * FROM t", { mariadb_server_prepare => 1 });
+ok(!$sth2->{Active});
 ok($sth2->execute());
-ok($sth2->fetchall_arrayref());
+ok($sth2->{Active});
 is_deeply($sth2->{NAME}, ["id"]);
-ok($sth2->finish());
+is_deeply($sth2->fetchall_arrayref(), [ [ 1 ] ]);
+ok(!$sth2->{Active});
+is_deeply($sth2->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG ]);
+
+ok($dbh->do("INSERT INTO t(id) VALUES(2)"));
+
+my $sth3 = $dbh->prepare("SELECT * FROM t");
+ok(!$sth3->{Active});
+ok($sth3->execute());
+ok($sth3->{Active});
+is_deeply($sth3->{NAME}, ["id"]);
+is_deeply($sth3->fetchrow_arrayref(), [ 1 ]);
+ok($sth3->{Active});
+is_deeply($sth3->{NAME}, ["id"]);
+is_deeply($sth3->fetchrow_arrayref(), [ 2 ]);
+ok(!$sth3->{Active});
+is_deeply($sth3->{NAME}, ["id"]);
+is_deeply($sth3->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG ]);
+
+my $sth4 = $dbh->prepare("SELECT * FROM t", { mariadb_server_prepare => 1 });
+ok(!$sth4->{Active});
+ok($sth4->execute());
+ok($sth4->{Active});
+is_deeply($sth4->{NAME}, ["id"]);
+is_deeply($sth4->fetchrow_arrayref(), [ 1 ]);
+ok($sth4->{Active});
+is_deeply($sth4->{NAME}, ["id"]);
+is_deeply($sth4->fetchrow_arrayref(), [ 2 ]);
+ok(!$sth4->{Active});
+is_deeply($sth4->{NAME}, ["id"]);
+is_deeply($sth4->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG ]);
+
+my $sth5 = $dbh->prepare("SELECT * FROM t");
+ok(!$sth5->{Active});
+ok($sth5->execute());
+ok($sth5->{Active});
+is_deeply($sth5->{NAME}, ["id"]);
+is_deeply($sth5->fetchrow_arrayref(), [ 1 ]);
+ok($sth5->{Active});
+is_deeply($sth5->{NAME}, ["id"]);
+ok($sth5->finish);
+ok(!$sth5->{Active});
+is_deeply($sth5->{NAME}, ["id"]);
+is_deeply($sth5->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG ]);
+
+my $sth6 = $dbh->prepare("SELECT * FROM t", { mariadb_server_prepare => 1 });
+ok(!$sth6->{Active});
+ok($sth6->execute());
+ok($sth6->{Active});
+is_deeply($sth6->{NAME}, ["id"]);
+is_deeply($sth6->fetchrow_arrayref(), [ 1 ]);
+ok($sth6->{Active});
+is_deeply($sth6->{NAME}, ["id"]);
+ok($sth6->finish);
+ok(!$sth6->{Active});
+is_deeply($sth6->{NAME}, ["id"]);
+is_deeply($sth6->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG ]);
+
+my $sth7 = $dbh->prepare("SELECT NULL as my_name LIMIT 0");
+ok(!$sth7->{Active});
+ok($sth7->execute());
+ok(!$sth7->{Active});
+is_deeply($sth7->{NAME}, ["my_name"]);
+ok(!$sth7->fetchrow_arrayref());
+ok(!$sth7->{Active});
+is_deeply($sth7->{mariadb_type}, [ DBD::MariaDB::TYPE_NULL ]);
+
+my $sth8 = $dbh->prepare("SELECT NULL as my_name LIMIT 0");
+ok(!$sth8->{Active});
+ok($sth8->execute());
+ok(!$sth8->{Active});
+is_deeply($sth8->{NAME}, ["my_name"]);
+ok(!$sth8->fetchrow_arrayref());
+ok(!$sth8->{Active});
+is_deeply($sth8->{mariadb_type}, [ DBD::MariaDB::TYPE_NULL ]);
+
+my $sth9 = $dbh->prepare("SELECT NULL as my_name LIMIT 0");
+ok(!$sth9->{Active});
+ok($sth9->execute());
+ok(!$sth9->{Active});
+is_deeply($sth9->{NAME}, ["my_name"]);
+is_deeply($sth9->fetchall_arrayref(), []);
+ok(!$sth9->{Active});
+is_deeply($sth9->{mariadb_type}, [ DBD::MariaDB::TYPE_NULL ]);
+
+my $sth10 = $dbh->prepare("SELECT NULL as my_name LIMIT 0");
+ok(!$sth10->{Active});
+ok($sth10->execute());
+ok(!$sth10->{Active});
+is_deeply($sth10->{NAME}, ["my_name"]);
+is_deeply($sth10->fetchall_arrayref(), []);
+ok(!$sth10->{Active});
+is_deeply($sth10->{mariadb_type}, [ DBD::MariaDB::TYPE_NULL ]);
 
 ok($dbh->disconnect());

--- a/t/40types.t
+++ b/t/40types.t
@@ -15,7 +15,7 @@ use vars qw($test_dsn $test_user $test_password);
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 
-plan tests => 78*2;
+plan tests => 70*2;
 
 for my $mariadb_server_prepare (0, 1) {
 $dbh->{mariadb_server_prepare} = $mariadb_server_prepare;
@@ -44,7 +44,6 @@ ok(!($sv->FLAGS & (SVf_IVisUV|SVf_NOK|SVf_POK)), "scalar is not unsigned intger 
 is_deeply($sth->{TYPE}, [ DBI::SQL_INTEGER ], "checking column type");
 is_deeply($sth->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG ], "checking mariadb column type");
 
-ok($sth->finish);
 ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 
 ok($dbh->do(qq{CREATE TABLE t_dbd_40types (num VARCHAR(10))}), "creating table");
@@ -69,11 +68,10 @@ ok(!($sv->FLAGS & (SVf_IOK|SVf_NOK)), "scalar is not intger or double");
 is_deeply($sth->{TYPE}, [ DBI::SQL_VARCHAR ], "checking column type");
 cmp_deeply($sth->{mariadb_type}, [ any(DBD::MariaDB::TYPE_VARCHAR, DBD::MariaDB::TYPE_VAR_STRING) ], "checking mariadb column type");
 
-ok($sth->finish);
 ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 
 SKIP: {
-skip "Clients < 5.0.3 do not support new decimal type from servers >= 5.0.3", 6 if $dbh->{mariadb_serverversion} >= 50003 and $dbh->{mariadb_clientversion} < 50003;
+skip "Clients < 5.0.3 do not support new decimal type from servers >= 5.0.3", 5 if $dbh->{mariadb_serverversion} >= 50003 and $dbh->{mariadb_clientversion} < 50003;
 
 ok($dbh->do(qq{CREATE TABLE t_dbd_40types (d DECIMAL(5,2))}), "creating table");
 
@@ -83,7 +81,6 @@ ok($sth->execute(), "getting table information");
 is_deeply($sth->{TYPE}, [ DBI::SQL_DECIMAL ], "checking column type");
 cmp_deeply($sth->{mariadb_type}, [ any(DBD::MariaDB::TYPE_DECIMAL, DBD::MariaDB::TYPE_NEWDECIMAL) ], "checking mariadb column type");
 
-ok($sth->finish);
 ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 }
 
@@ -96,10 +93,8 @@ ok($dbh->do(qq{CREATE TABLE t_dbd_40types (num DOUBLE)}), "creating table");
 $sth= $dbh->prepare("INSERT INTO t_dbd_40types VALUES (?)");
 ok($sth->bind_param(1, 2.1, DBI::SQL_DOUBLE), "binding parameter");
 ok($sth->execute(), "inserting data");
-ok($sth->finish);
 ok($sth->bind_param(1, -1, DBI::SQL_DOUBLE), "binding parameter");
 ok($sth->execute(), "inserting data");
-ok($sth->finish);
 
 my $ret = $dbh->selectall_arrayref("SELECT * FROM t_dbd_40types");
 cmp_deeply($ret, [ [num(2.1, 0.00001)], [num(-1, 0.00001)] ]);
@@ -128,7 +123,6 @@ ok(!($sv->FLAGS & (SVf_IOK|SVf_POK)), "scalar is not integer or string");
 is_deeply($sth->{TYPE}, [ DBI::SQL_DOUBLE ], "checking column type");
 is_deeply($sth->{mariadb_type}, [ DBD::MariaDB::TYPE_DOUBLE ], "checking mariadb column type");
 
-ok($sth->finish);
 ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 
 #
@@ -164,7 +158,6 @@ ok(!($sv->FLAGS & (SVf_NOK|SVf_POK)), "scalar is not double or string");
 is_deeply($sth->{TYPE}, [ DBI::SQL_INTEGER ], "checking column type");
 is_deeply($sth->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG ], "checking mariadb column type");
 
-ok($sth->finish);
 ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 
 # https://github.com/gooddata/DBD-MariaDB/issues/109: Check DBI::SQL_BIGINT type
@@ -173,7 +166,6 @@ $sth = $dbh->prepare("SELECT * FROM t_dbd_40types");
 ok($sth->execute());
 is_deeply($sth->{TYPE}, [ DBI::SQL_BIGINT ], "checking column type of bigint");
 is_deeply($sth->{mariadb_type}, [ DBD::MariaDB::TYPE_LONGLONG ], "checking mariadb column type of bigint");
-ok($sth->finish);
 ok($dbh->do(qq{DROP TABLE t_dbd_40types}), "cleaning up");
 
 }

--- a/t/41bindparam.t
+++ b/t/41bindparam.t
@@ -11,7 +11,7 @@ require 'lib.pl';
 my ($dbh, $sth);
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
-plan tests => 11;
+plan tests => 10;
 
 my ($rows, $errstr, $ret_ref);
 ok $dbh->do("drop table if exists dbd_mysql_41bindparam"), "drop table dbd_mysql_41bindparam";
@@ -31,7 +31,5 @@ ok $sth->execute(), 'execute';
 ok ($sth= $dbh->prepare("DROP TABLE dbd_mysql_41bindparam"));
 
 ok $sth->execute();
-
-ok $sth->finish;
 
 ok $dbh->disconnect;

--- a/t/41blobs_prepare.t
+++ b/t/41blobs_prepare.t
@@ -12,7 +12,7 @@ require 'lib.pl';
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
   { RaiseError => 1, PrintError => 0 });
 
-plan tests => 25;
+plan tests => 21;
 
 my @chars = grep !/[0O1Iil]/, 0..9, 'A'..'Z', 'a'..'z';
 my $blob1= join '', map { $chars[rand @chars] } 0 .. 10000;
@@ -50,8 +50,6 @@ ok defined($sth);
 
 ok $sth->execute(1, $blob1), "inserting \$blob1";
 
-ok $sth->finish;
-
 ok ($sth= $dbh->prepare("SELECT * FROM dbd_mysql_41blobs_prepare WHERE id = 1"));
 
 ok $sth->execute, "select from dbd_mysql_41blobs_prepare";
@@ -64,13 +62,9 @@ is $$row[0], 1, "first row id == 1";
 
 cmp_ok $$row[1], 'eq', $blob1, ShowBlob($blob1);
 
-ok $sth->finish;
-
 ok ($sth= $dbh->prepare("UPDATE dbd_mysql_41blobs_prepare SET name = ? WHERE id = 1"));
 
 ok $sth->execute($blob2), 'inserting $blob2';
-
-ok ($sth->finish);
 
 ok ($sth= $dbh->prepare("SELECT * FROM dbd_mysql_41blobs_prepare WHERE id = 1"));
 
@@ -83,8 +77,6 @@ is scalar @$row, 2, 'two rows';
 is $$row[0], 1, 'row id == 1';
 
 cmp_ok $$row[1], 'eq', $blob2, ShowBlob($blob2);
-
-ok ($sth->finish);
 
 ok $dbh->do("DROP TABLE dbd_mysql_41blobs_prepare"), "drop dbd_mysql_41blobs_prepare";
 

--- a/t/42bindparam.t
+++ b/t/42bindparam.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 
-plan tests => 12;
+plan tests => 11;
 
 ok $dbh->do("drop table if exists dbd_mysql_t42bindparams");
 
@@ -38,7 +38,5 @@ ok $sth->bind_param(2,.3333333,DBI::SQL_DOUBLE);
 ok $sth->execute();
 
 ok $dbh->do("DROP TABLE dbd_mysql_t42bindparams");
-
-ok $sth->finish;
 
 ok $dbh->disconnect;

--- a/t/44call_placeholder.t
+++ b/t/44call_placeholder.t
@@ -14,7 +14,7 @@ plan skip_all => "CREATE PROCEDURE is supported since MySQL version 5.0" if $dbh
 
 plan skip_all => $dbh->errstr() if !CheckRoutinePerms($dbh);
 
-plan tests => 13;
+plan tests => 12;
 
 ok $dbh->do('DROP PROCEDURE IF EXISTS t44_call_placeholder');
 
@@ -28,7 +28,6 @@ EOPROC
 ok my $sth = $dbh->prepare('CALL t44_call_placeholder(?)');
 ok $sth->execute(10);
 is_deeply $sth->fetchall_arrayref(), [ [5, 10] ];
-ok $sth->finish();
 
 ok $dbh->do('DROP PROCEDURE t44_call_placeholder');
 

--- a/t/44limit_placeholder.t
+++ b/t/44limit_placeholder.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 0, AutoCommit => 0, mariadb_server_prepare => 1 });
 
-plan tests => 38;
+plan tests => 32;
 
 ok $dbh->do('CREATE TEMPORARY TABLE t(id INT)');
 ok $dbh->do('CREATE TEMPORARY TABLE t2(id INT)');
@@ -20,7 +20,6 @@ ok $dbh->do('INSERT INTO t(id) VALUES(20)');
 ok my $sth = $dbh->prepare('SELECT id FROM t ORDER BY id LIMIT ?');
 ok $sth->execute(1);
 is_deeply $sth->fetchall_arrayref(), [ [10] ];
-ok $sth->finish();
 
 ok $dbh->do('INSERT INTO t2(id) SELECT id FROM t ORDER BY id LIMIT ?', undef, 1);
 is_deeply $dbh->selectall_arrayref('SELECT id FROM t2'), [ [10] ];
@@ -29,7 +28,6 @@ ok $dbh->do('TRUNCATE TABLE t2');
 ok $sth = $dbh->prepare('SELECT id FROM t ORDER BY id LIMIT ?,?');
 ok $sth->execute(0, 1);
 is_deeply $sth->fetchall_arrayref(), [ [10] ];
-ok $sth->finish();
 
 ok $dbh->do('INSERT INTO t2(id) SELECT id FROM t ORDER BY id LIMIT ?,?', undef, 0, 1);
 is_deeply $dbh->selectall_arrayref('SELECT id FROM t2'), [ [10] ];
@@ -38,7 +36,6 @@ ok $dbh->do('TRUNCATE TABLE t2');
 ok $sth = $dbh->prepare('SELECT id FROM t ORDER BY id LIMIT ? OFFSET ?');
 ok $sth->execute(1, 0);
 is_deeply $sth->fetchall_arrayref(), [ [10] ];
-ok $sth->finish();
 
 ok $dbh->do('INSERT INTO t2(id) SELECT id FROM t ORDER BY id LIMIT ? OFFSET ?', undef, 1, 0);
 is_deeply $dbh->selectall_arrayref('SELECT id FROM t2'), [ [10] ];
@@ -47,16 +44,13 @@ ok $dbh->do('TRUNCATE TABLE t2');
 ok $sth = $dbh->prepare('select id from t order by id LiMIt    ?,?');
 ok $sth->execute(0, 1);
 is_deeply $sth->fetchall_arrayref(), [ [10] ];
-ok $sth->finish();
 
 ok $sth = $dbh->prepare('select id from t order by id LiMIt  0  ,?');
 ok $sth->execute(1);
 is_deeply $sth->fetchall_arrayref(), [ [10] ];
-ok $sth->finish();
 
 ok $sth = $dbh->prepare('select id from t order by id lImIt  1  OFFSET  ?');
 ok $sth->execute(0);
 is_deeply $sth->fetchall_arrayref(), [ [10] ];
-ok $sth->finish();
 
 ok $dbh->disconnect();

--- a/t/45bind_no_backslash_escapes.t
+++ b/t/45bind_no_backslash_escapes.t
@@ -22,7 +22,7 @@ if ($dbh->{mariadb_clientversion} < 50001) {
     $id2_quoted_no_backslash = q(X'737472696E675C737472696E6722737472696E6727737472696E67');
 }
 
-plan tests => 24;
+plan tests => 20;
 
 ok $dbh->do('CREATE TEMPORARY TABLE t(id VARCHAR(255), value TEXT)');
 ok $dbh->do('INSERT INTO t(id, value) VALUES(?, ?)', undef, $id1, 'value1');
@@ -41,12 +41,10 @@ for my $server_prepare (0, 1) {
     ok $sth->bind_param(1, $id1);
     ok $sth->execute();
     is_deeply $sth->fetchall_arrayref(), [ [ $id1, 'value1' ] ];
-    ok $sth->finish();
 
     ok $sth->bind_param(1, $id2);
     ok $sth->execute();
     is_deeply $sth->fetchall_arrayref(), [ [ $id2, 'value2' ] ];
-    ok $sth->finish();
 
 }
 

--- a/t/50chopblanks.t
+++ b/t/50chopblanks.t
@@ -12,7 +12,7 @@ my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0 });
 $dbh->disconnect;
 
-plan tests => (8 + ((5 + 8 + 8) * 4)) * 2;
+plan tests => (6 + ((5 + 8 + 8) * 4)) * 2;
 
 for my $mariadb_server_prepare (0, 1) {
 $dbh = DBI->connect("$test_dsn;mariadb_server_prepare=$mariadb_server_prepare;mariadb_server_prepare_disable_fallback=1", $test_user, $test_password,
@@ -76,8 +76,6 @@ for my $ref (@$rows) {
 	}
 
 }
-ok $sth->finish;
-ok $sth2->finish;
 ok $dbh->do("DROP TABLE dbd_mysql_t50chopblanks"), "drop dbd_mysql_t50chopblanks";
 ok $dbh->disconnect;
 }

--- a/t/51bind_type_guessing.t
+++ b/t/51bind_type_guessing.t
@@ -76,6 +76,7 @@ ok $rows= $sth3->execute('-12.E-100', 104);
 
 ok $sth3= $dbh->prepare("select * from dbd_mysql_t51bind_type_guessing limit ?");
 ok $rows= $sth3->execute(1);
+$sth3->finish();
 ok $rows= $sth3->execute('   1');
 $sth3->finish();
 

--- a/t/52comment.t
+++ b/t/52comment.t
@@ -34,7 +34,6 @@ ok $sth= $dbh->prepare($statement);
 my $rows;
 ok $rows= $sth->execute('1');
 cmp_ok $rows, '==',  1;
-$sth->finish();
 
 $statement= <<EOSTMT;
 SELECT id 

--- a/t/53comment.t
+++ b/t/53comment.t
@@ -32,7 +32,6 @@ ok $sth= $dbh->prepare($statement);
 my $rows;
 ok $rows= $sth->execute('1');
 cmp_ok $rows, '==',  1;
-$sth->finish();
 
 
 my $retrow;

--- a/t/55unicode.t
+++ b/t/55unicode.t
@@ -30,7 +30,6 @@ for my $mariadb_server_prepare (0, 1) {
             $sth->execute();
             my $fetch = $dbh->selectrow_array("SELECT s FROM t");
             is($fetch, $ins, "test $ins without bind");
-            $sth->finish();
             $dbh->do("DROP TEMPORARY TABLE t");
         }
         SKIP: {
@@ -40,7 +39,6 @@ for my $mariadb_server_prepare (0, 1) {
             $sth->execute($ins);
             my $fetch = $dbh->selectrow_array("SELECT s FROM t");
             is($fetch, $ins, "test $ins with bind");
-            $sth->finish();
             $dbh->do("DROP TEMPORARY TABLE t");
         }
     }

--- a/t/55utf8.t
+++ b/t/55utf8.t
@@ -16,7 +16,7 @@ binmode $tb->todo_output,    ":utf8";
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 
-plan tests => 42 * 2;
+plan tests => 40 * 2;
 
 for my $mariadb_server_prepare (0, 1) {
 $dbh= DBI->connect("$test_dsn;mariadb_server_prepare=$mariadb_server_prepare;mariadb_server_prepare_disable_fallback=1", $test_user, $test_password,
@@ -76,7 +76,6 @@ ok $sth->bind_param(5, $unicode_str2);
 ok $sth->bind_param(6, $unicode_str);
 ok $sth->bind_param(7, $unicode_str2);
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
-ok $sth->finish;
 
 cmp_ok($dbh->{mariadb_warning_count}, '==', 1, 'got warning for INSERT') or do { diag("SHOW WARNINGS:"); diag($_->[2]) foreach $dbh->selectall_array("SHOW WARNINGS", { mariadb_server_prepare => 0 }); };
 my (undef, undef, $warning) = $dbh->selectrow_array("SHOW WARNINGS", { mariadb_server_prepare => 0 });
@@ -104,8 +103,6 @@ cmp_ok $ref->[6], 'eq', $ascii_str;
 cmp_ok $ref->[7], 'eq', $latin1_str2;
 
 cmp_ok $ref->[1], 'eq', $blob, "compare $ref->[1] eq $blob";
-
-ok $sth->finish;
 
 my $prev_charset = $dbh->selectrow_array('SELECT @@character_set_results');
 ok $dbh->do("SET character_set_results='latin1'"), "SET character_set_results='latin1'";

--- a/t/55utf8mb4.t
+++ b/t/55utf8mb4.t
@@ -24,7 +24,6 @@ $sth = $dbh->prepare($query) or die "$DBI::errstr";
 ok $sth->execute;
 
 ok(my $ref = $sth->fetchrow_arrayref, 'fetch row');
-ok($sth->finish, 'close sth');
 cmp_ok $ref->[0], 'eq', "😈", 'test U+1F608';
 cmp_ok $ref->[1], 'eq', "F09F9888";
 

--- a/t/60leaks.t
+++ b/t/60leaks.t
@@ -303,7 +303,6 @@ for (my $i = 0; $i < $COUNT_PREPARE; $i++) {
         $sth->execute();
         my $row;
         while ($row = $sth->fetchrow_arrayref()) { }
-        $sth->finish();
     }
 
     if ($i % 100 == 99) {
@@ -344,7 +343,6 @@ for (my $i = 0; $i < $COUNT_PREPARE; $i++) {
         $sth->execute();
         my $row;
         while ($row = $sth->fetchrow_hashref()) { }
-        $sth->finish();
     }
 
     if ($i % 100 == 99) {

--- a/t/65types.t
+++ b/t/65types.t
@@ -9,7 +9,7 @@ require 'lib.pl';
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
-plan tests => 19;
+plan tests => 18;
 
 ok $dbh->do("drop table if exists dbd_mysql_65types");
 
@@ -50,8 +50,6 @@ ok $sth->bind_param(1,10001,DBI::SQL_INTEGER);
 ok $sth->bind_param(2,.3333333,DBI::SQL_DOUBLE);
 
 ok $sth->execute();
-
-ok $sth->finish;
 
 ok $dbh->do("DROP TABLE dbd_mysql_65types");
 

--- a/t/75supported_sql.t
+++ b/t/75supported_sql.t
@@ -12,7 +12,7 @@ my ($row, $vers, $test_procs);
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
   { RaiseError => 1, PrintError => 0 });
 
-plan tests => 12;
+plan tests => 11;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t75supported");
 
@@ -33,8 +33,6 @@ ok $sth->execute();
 ok ($row= $sth->fetchrow_arrayref);
 
 cmp_ok $row->[0], 'eq', 'dbd_mysql_t75supported', "\$row->[0] eq dbd_mysql_t75supported";
-
-ok $sth->finish;
 
 ok $dbh->do("DROP TABLE dbd_mysql_t75supported"), "drop dbd_mysql_t75supported";
 

--- a/t/76multi_statement.t
+++ b/t/76multi_statement.t
@@ -14,7 +14,7 @@ my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0,
                         mariadb_multi_statements => 1 });
 
-plan tests => 73;
+plan tests => 71;
 
 ok (defined $dbh, "Connected to database with multi statement support");
 
@@ -42,7 +42,6 @@ $dbh->{mariadb_server_prepare}= 0;
   is($sth->rows, 2, "Second update affected 2 rows");
   is($sth->{mariadb_warning_count}, 2, "Second update had 2 warnings");
   ok(not $sth->more_results());
-  ok($sth->finish());
 
   # Now run it again without calling more_results().
   ok($sth->execute(), "Execute updates again");
@@ -72,7 +71,6 @@ $dbh->{mariadb_server_prepare}= 0;
   is($sth->last_insert_id(), 2);
   is($dbh->last_insert_id(undef, undef, undef, undef), 2);
   ok(not $sth->more_results());
-  ok($sth->finish());
 
   # Check that $dbh->last_insert_id works after $dbh->do with multi statements
   ok($dbh->do("INSERT INTO dbd_mysql_t76multi2 VALUES(3); INSERT INTO dbd_mysql_t76multi2 VALUES(4);"));

--- a/t/76multi_statement.t
+++ b/t/76multi_statement.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More;
 use DBI;
+use DBD::MariaDB;
 use lib 't', '.';
 require 'lib.pl';
 $|= 1;
@@ -13,7 +14,7 @@ my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0,
                         mariadb_multi_statements => 1 });
 
-plan tests => 51;
+plan tests => 73;
 
 ok (defined $dbh, "Connected to database with multi statement support");
 
@@ -95,5 +96,29 @@ $dbh->{mariadb_server_prepare}= 0;
   ok($dbh->do("SELECT 1"));
   is($dbh->last_insert_id(undef, undef, undef, undef), 10, '$dbh->last_insert_id is correct after multi statement prepare and execute without finish followed by $dbh->do');
   ok($sth->finish());
+
+  # Check that statement attributes are correct after calling more_results
+  ok($dbh->do("CREATE TEMPORARY TABLE dbd_mysql_t76multi3 (name_id1 INT, name_id2 INT)"));
+  ok($sth = $dbh->prepare("SELECT name_id1 FROM dbd_mysql_t76multi3; INSERT INTO dbd_mysql_t76multi2 VALUES(11); SELECT name_id1, name_id2 FROM dbd_mysql_t76multi3; SYNTAX ERROR"));
+  ok($sth->execute());
+  is($sth->{NUM_OF_FIELDS}, 1);
+  is($sth->{NUM_OF_PARAMS}, 0);
+  is_deeply($sth->{NAME}, [ 'name_id1' ]);
+  is_deeply($sth->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG ]);
+  ok($sth->more_results());
+  is($sth->{NUM_OF_FIELDS}, 0);
+  is($sth->{NUM_OF_PARAMS}, 0);
+  ok(!eval { $sth->{NAME} });
+  ok(!eval { $sth->{mariadb_type} });
+  ok($sth->more_results());
+  is($sth->{NUM_OF_FIELDS}, 2);
+  is($sth->{NUM_OF_PARAMS}, 0);
+  is_deeply($sth->{NAME}, [ 'name_id1', 'name_id2' ]);
+  is_deeply($sth->{mariadb_type}, [ DBD::MariaDB::TYPE_LONG, DBD::MariaDB::TYPE_LONG ]);
+  ok(!eval { $sth->more_results() });
+  is($sth->{NUM_OF_FIELDS}, 0);
+  is($sth->{NUM_OF_PARAMS}, 0);
+  ok(!eval { $sth->{NAME} });
+  ok(!eval { $sth->{mariadb_type} });
 
 $dbh->disconnect();

--- a/t/80procs.t
+++ b/t/80procs.t
@@ -120,12 +120,12 @@ ok defined $resultset;
 
 is @$resultset, 3, "3 Rows in resultset";
 
-ok $sth->more_results();
+is $sth->more_results(), 1, "each CALL returns a result to indicate the call status";
 
-is $sth->{NUM_OF_FIELDS}, 0, "NUM_OF_FIELDS == 0"; +
+is $sth->{NUM_OF_FIELDS}, 0, "NUM_OF_FIELDS == 0";
+
+ok !$sth->more_results();
 
 local $SIG{__WARN__} = sub { die @_ };
-
-ok $sth->finish;
 
 ok $dbh->disconnect();

--- a/t/81procs.t
+++ b/t/81procs.t
@@ -25,7 +25,7 @@ if (!CheckRoutinePerms($dbh)) {
         $dbh->errstr();
 }
 
-plan tests => 32;
+plan tests => 31;
 
 $dbh->disconnect();
 
@@ -127,7 +127,5 @@ is $sth->{NUM_OF_FIELDS}, 0, "NUM_OF_FIELDS == 0";
 ok !$sth->more_results();
 
 local $SIG{__WARN__} = sub { die @_ };
-
-ok $sth->finish;
 
 ok $dbh->disconnect();

--- a/t/85init_command.t
+++ b/t/85init_command.t
@@ -27,7 +27,5 @@ ok(my @fetchrow = $sth->fetchrow_array());
 
 is($fetchrow[1],'7','session variable is 7');
 
-$sth->finish();
-
 $dbh->disconnect();
 

--- a/t/87async.t
+++ b/t/87async.t
@@ -16,7 +16,7 @@ my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
 if ($dbh->{mariadb_serverversion} < 50012) {
     plan skip_all => "Servers < 5.0.12 do not support SLEEP()";
 }
-plan tests => 92;
+plan tests => 96;
 
 is $dbh->get_info($GetInfoType{'SQL_ASYNC_MODE'}), 2; # statement-level async
 is $dbh->get_info($GetInfoType{'SQL_MAX_ASYNC_CONCURRENT_STATEMENTS'}), 1;
@@ -214,22 +214,26 @@ $sth->finish;
 $sth->execute(1);
 $row = $sth->fetch;
 is_deeply $row, [1, 1, 2, 3];
+is $sth->rows, 1;
 $sth->finish;
 
 $sth->execute(1);
 $row = $sth->fetchrow_arrayref;
 is_deeply $row, [1, 1, 2, 3];
+is $sth->rows, 1;
 $sth->finish;
 
 $sth->execute(1);
 my @row = $sth->fetchrow_array;
 is_deeply \@row, [1, 1, 2, 3];
+is $sth->rows, 1;
 $sth->finish;
 
 $sth->execute(1);
 $row = $sth->fetchrow_hashref;
 cmp_bag [ keys %$row ], [qw/1 value0 value1 value2/];
 cmp_bag [ values %$row ], [1, 1, 2, 3];
+is $sth->rows, 1;
 $sth->finish;
 
 undef $sth;

--- a/t/87async.t
+++ b/t/87async.t
@@ -16,7 +16,7 @@ my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
 if ($dbh->{mariadb_serverversion} < 50012) {
     plan skip_all => "Servers < 5.0.12 do not support SLEEP()";
 }
-plan tests => 96;
+plan tests => 137;
 
 is $dbh->get_info($GetInfoType{'SQL_ASYNC_MODE'}), 2; # statement-level async
 is $dbh->get_info($GetInfoType{'SQL_MAX_ASYNC_CONCURRENT_STATEMENTS'}), 1;
@@ -93,23 +93,31 @@ is $b, 1;
 is $c, 2;
 
 $sth = $dbh->prepare('SELECT SLEEP(2)');
+ok !$sth->{Active};
 ok !defined($sth->mariadb_async_ready);
 $start = Time::HiRes::gettimeofday();
 ok $sth->execute;
 $end = Time::HiRes::gettimeofday();
 cmp_ok(($end - $start), '>=', 1.9);
+ok $sth->{Active};
+ok $sth->finish;
+ok !$sth->{Active};
 
 $sth = $dbh->prepare('SELECT SLEEP(2)', { mariadb_async => 1 });
+ok !$sth->{Active};
 ok !defined($sth->mariadb_async_ready);
 $start = Time::HiRes::gettimeofday();
 ok $sth->execute;
 ok defined($sth->mariadb_async_ready);
 $end = Time::HiRes::gettimeofday();
 cmp_ok(($end - $start), '<', 2);
+ok $sth->{Active};
 
 sleep 1 until $sth->mariadb_async_ready;
 
+ok $sth->{Active};
 my $row = $sth->fetch;
+ok !$sth->{Active};
 $end = Time::HiRes::gettimeofday();
 ok $row;
 is $row->[0], 0;
@@ -126,16 +134,19 @@ ok $dbh->errstr;
 $dbh->do('DELETE FROM async_test');
 
 $sth = $dbh->prepare('INSERT INTO async_test VALUES(SLEEP(2), ?, ?)', { mariadb_async => 1 });
+ok !$sth->{Active};
 $start = Time::HiRes::gettimeofday();
 $rows = $sth->execute(1, 2);
 $end = Time::HiRes::gettimeofday();
 cmp_ok(($end - $start), '<', 2);
+ok $sth->{Active};
 ok $rows;
 is $rows, '0E0';
 
 $rows = $sth->mariadb_async_result;
 $end = Time::HiRes::gettimeofday();
 cmp_ok(($end - $start), '>=', 1.9);
+ok !$sth->{Active};
 is $rows, 1;
 
 ( $a, $b, $c ) = $dbh->selectrow_array('SELECT * FROM async_test');
@@ -164,10 +175,13 @@ ok $rows;
 is $rows, '0E0';
 
 $sth  = $dbh->prepare('UPDATE async_test SET value0 = 0 WHERE value0 = 999', { mariadb_async => 1 });
+ok !$sth->{Active};
 $rows = $sth->execute;
+ok $sth->{Active};
 ok $rows;
 is $rows, '0E0';
 $rows = $sth->mariadb_async_result;
+ok !$sth->{Active};
 ok $rows;
 is $rows, '0E0';
 
@@ -179,7 +193,9 @@ $rows = $dbh->do('INSERT INTO async_test VALUES(1, 2, 3)');
 is $rows, 1;
 
 $sth = $dbh->prepare('SELECT 1, value0, value1, value2 FROM async_test WHERE value0 = ?', { mariadb_async => 1 });
+ok !$sth->{Active};
 $sth->execute(1);
+ok $sth->{Active};
 is $sth->{'NUM_OF_FIELDS'}, undef;
 is $sth->{'NUM_OF_PARAMS'}, 1;
 is $sth->{'NAME'}, undef;
@@ -195,6 +211,7 @@ is $sth->{'NULLABLE'}, undef;
 is $sth->{'Database'}, $dbh;
 is $sth->{'Statement'}, 'SELECT 1, value0, value1, value2 FROM async_test WHERE value0 = ?';
 $sth->mariadb_async_result;
+ok $sth->{Active};
 is $sth->{'NUM_OF_FIELDS'}, 4;
 is $sth->{'NUM_OF_PARAMS'}, 1;
 cmp_bag $sth->{'NAME'}, [qw/1 value0 value1 value2/];
@@ -210,31 +227,60 @@ is ref($sth->{'NULLABLE'}), 'ARRAY';
 is $sth->{'Database'}, $dbh;
 is $sth->{'Statement'}, 'SELECT 1, value0, value1, value2 FROM async_test WHERE value0 = ?';
 $sth->finish;
+ok !$sth->{Active};
 
 $sth->execute(1);
+ok $sth->{Active};
 $row = $sth->fetch;
+ok !$sth->{Active};
 is_deeply $row, [1, 1, 2, 3];
 is $sth->rows, 1;
-$sth->finish;
 
 $sth->execute(1);
+ok $sth->{Active};
+$sth->mariadb_async_result;
+ok $sth->{Active};
+$row = $sth->fetch;
+ok !$sth->{Active};
+is_deeply $row, [1, 1, 2, 3];
+is $sth->rows, 1;
+
+$sth->execute(1);
+ok $sth->{Active};
 $row = $sth->fetchrow_arrayref;
+ok !$sth->{Active};
 is_deeply $row, [1, 1, 2, 3];
 is $sth->rows, 1;
-$sth->finish;
 
 $sth->execute(1);
+ok $sth->{Active};
 my @row = $sth->fetchrow_array;
+ok !$sth->{Active};
 is_deeply \@row, [1, 1, 2, 3];
 is $sth->rows, 1;
-$sth->finish;
 
 $sth->execute(1);
+ok $sth->{Active};
 $row = $sth->fetchrow_hashref;
+ok !$sth->{Active};
 cmp_bag [ keys %$row ], [qw/1 value0 value1 value2/];
 cmp_bag [ values %$row ], [1, 1, 2, 3];
 is $sth->rows, 1;
-$sth->finish;
 
-undef $sth;
+$sth = $dbh->prepare('UPDATE async_test SET value0 = 2 WHERE value0 = 1', { mariadb_async => 1 });
+ok !$sth->{Active};
+ok $sth->execute();
+ok $sth->{Active};
+ok $sth->mariadb_async_result;
+ok !$sth->{Active};
+
+$sth = $dbh->prepare('SYNTAX ERROR', { mariadb_async => 1 });
+ok !$sth->{Active};
+ok $sth->execute();
+ok $sth->{Active};
+ok !$sth->mariadb_async_result;
+ok !$sth->{Active};
+
+local $SIG{__WARN__} = sub { die @_ };
+
 ok $dbh->disconnect;

--- a/t/88async-multi-stmts.t
+++ b/t/88async-multi-stmts.t
@@ -10,19 +10,31 @@ require 'lib.pl';
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 0, PrintError => 0, AutoCommit => 0, mariadb_multi_statements => 1 });
-plan tests => 65;
+plan tests => 104;
 
-$dbh->do(<<SQL);
+ok $dbh->do(<<SQL);
 CREATE TEMPORARY TABLE async_test (
     value INTEGER AUTO_INCREMENT PRIMARY KEY
 );
 SQL
 
 my $sth0 = $dbh->prepare('INSERT INTO async_test VALUES(1)', { mariadb_async => 1 });
+ok $sth0 or die $dbh->err;
 my $sth1 = $dbh->prepare('INSERT INTO async_test VALUES(2)', { mariadb_async => 1 });
+ok $sth1 or die $dbh->err;
 my $sth2 = $dbh->prepare('INSERT INTO async_test VALUES(3); INSERT INTO async_test VALUES(4);', { mariadb_async => 1 });
+ok $sth2 or die $dbh->err;
 
-$sth0->execute;
+ok !$sth0->{Active};
+ok !$sth1->{Active};
+ok !$sth2->{Active};
+
+ok $sth0->execute;
+
+ok $sth0->{Active};
+ok !$sth1->{Active};
+ok !$sth2->{Active};
+
 ok !defined($sth1->mariadb_async_ready);
 ok $sth1->errstr;
 ok !defined($sth1->mariadb_async_result);
@@ -33,14 +45,27 @@ ok !$sth1->errstr;
 ok defined($sth0->mariadb_async_result);
 ok !$sth1->errstr;
 
+ok !$sth0->{Active};
+ok !$sth1->{Active};
+ok !$sth2->{Active};
+
 is($sth0->last_insert_id(), 1);
 is($dbh->last_insert_id(undef, undef, undef, undef), 1);
 
-$sth2->execute;
+ok $sth2->execute;
+
+ok !$sth0->{Active};
+ok !$sth1->{Active};
+ok $sth2->{Active};
+
 ok !defined($sth1->mariadb_async_ready);
 ok $sth1->err;
 ok !defined($sth1->mariadb_async_result);
 ok $sth1->err;
+
+ok !$sth0->{Active};
+ok !$sth1->{Active};
+ok $sth2->{Active};
 
 is($sth0->last_insert_id(), 1);
 is($dbh->last_insert_id(undef, undef, undef, undef), 1);
@@ -54,6 +79,10 @@ is($dbh->last_insert_id(undef, undef, undef, undef), 1);
 ok defined($sth2->mariadb_async_result);
 ok !$sth2->err;
 
+ok !$sth0->{Active};
+ok !$sth1->{Active};
+ok $sth2->{Active};
+
 is($sth0->last_insert_id(), 1);
 is($sth2->last_insert_id(), 3);
 is($dbh->last_insert_id(undef, undef, undef, undef), 3);
@@ -62,13 +91,21 @@ ok $sth2->more_results;
 ok defined($sth2->mariadb_async_result);
 ok !$sth2->err;
 
+ok !$sth0->{Active};
+ok !$sth1->{Active};
+ok !$sth2->{Active};
+
 is($sth0->last_insert_id(), 1);
 is($sth2->last_insert_id(), 4);
 is($dbh->last_insert_id(undef, undef, undef, undef), 4);
 
 ok !$sth2->more_results;
 
-$dbh->do('INSERT INTO async_test VALUES(5)', { mariadb_async => 1 });
+ok !$sth0->{Active};
+ok !$sth1->{Active};
+ok !$sth2->{Active};
+
+ok $dbh->do('INSERT INTO async_test VALUES(5)', { mariadb_async => 1 });
 
 is($sth0->last_insert_id(), 1);
 is($sth2->last_insert_id(), 4);
@@ -92,36 +129,41 @@ my $sth3 = $dbh->prepare('INSERT INTO async_test VALUES(6); INSERT INTO async_te
 
 ok $sth3 or die $dbh->err;
 
+ok !$sth3->{Active};
 ok $sth3->execute();
+ok $sth3->{Active};
 
 is($sth0->last_insert_id(), 1);
 is($sth2->last_insert_id(), 4);
 is($dbh->last_insert_id(undef, undef, undef, undef), 5);
 
+ok $sth3->{Active};
 ok $sth3->mariadb_async_result();
+ok $sth3->{Active};
 
 is($sth0->last_insert_id(), 1);
 is($sth2->last_insert_id(), 4);
 is($sth3->last_insert_id(), 6);
 is($dbh->last_insert_id(undef, undef, undef, undef), 6);
 
+ok $sth3->{Active};
 ok $sth3->more_results();
+ok $sth3->{Active};
 
 is($sth0->last_insert_id(), 1);
 is($sth2->last_insert_id(), 4);
 is($sth3->last_insert_id(), 7);
 is($dbh->last_insert_id(undef, undef, undef, undef), 7);
 
+ok $sth3->{Active};
 ok !$sth3->more_results();
+ok !$sth3->{Active};
 
 is($sth0->last_insert_id(), 1);
 is($sth2->last_insert_id(), 4);
 is($sth3->last_insert_id(), 7);
 is($dbh->last_insert_id(undef, undef, undef, undef), 7);
 
-undef $sth0;
-undef $sth1;
-undef $sth2;
-undef $sth3;
+local $SIG{__WARN__} = sub { die @_ };
 
 $dbh->disconnect;

--- a/t/88async-multi-stmts.t
+++ b/t/88async-multi-stmts.t
@@ -10,7 +10,7 @@ require 'lib.pl';
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 0, PrintError => 0, AutoCommit => 0, mariadb_multi_statements => 1 });
-plan tests => 45;
+plan tests => 65;
 
 $dbh->do(<<SQL);
 CREATE TEMPORARY TABLE async_test (
@@ -88,8 +88,40 @@ is($sth0->last_insert_id(), 1);
 is($sth2->last_insert_id(), 4);
 is($dbh->last_insert_id(undef, undef, undef, undef), 5);
 
+my $sth3 = $dbh->prepare('INSERT INTO async_test VALUES(6); INSERT INTO async_test VALUES(7); SYNTAX ERROR; INSERT INTO async_test VALUES(8)', { mariadb_async => 1 });
+
+ok $sth3 or die $dbh->err;
+
+ok $sth3->execute();
+
+is($sth0->last_insert_id(), 1);
+is($sth2->last_insert_id(), 4);
+is($dbh->last_insert_id(undef, undef, undef, undef), 5);
+
+ok $sth3->mariadb_async_result();
+
+is($sth0->last_insert_id(), 1);
+is($sth2->last_insert_id(), 4);
+is($sth3->last_insert_id(), 6);
+is($dbh->last_insert_id(undef, undef, undef, undef), 6);
+
+ok $sth3->more_results();
+
+is($sth0->last_insert_id(), 1);
+is($sth2->last_insert_id(), 4);
+is($sth3->last_insert_id(), 7);
+is($dbh->last_insert_id(undef, undef, undef, undef), 7);
+
+ok !$sth3->more_results();
+
+is($sth0->last_insert_id(), 1);
+is($sth2->last_insert_id(), 4);
+is($sth3->last_insert_id(), 7);
+is($dbh->last_insert_id(undef, undef, undef, undef), 7);
+
 undef $sth0;
 undef $sth1;
 undef $sth2;
+undef $sth3;
 
 $dbh->disconnect;

--- a/t/89async-method-check.t
+++ b/t/89async-method-check.t
@@ -30,6 +30,8 @@ table_info         column_info        primary_key_info   primary_key
 foreign_key_info   statistics_info    tables             quote
 /;
 
+push @db_unsafe_methods, 'selectall_array' if DBI::db->can('selectall_array');
+
 my @st_safe_methods   = qw/
 fetchrow_arrayref fetch            fetchrow_array fetchrow_hashref
 fetchall_arrayref fetchall_hashref finish         rows
@@ -54,6 +56,7 @@ my %dbh_args = (
     selectrow_array     => ['SELECT 1'],
     selectrow_arrayref  => ['SELECT 1'],
     selectrow_hashref   => ['SELECT 1'],
+    selectall_array     => ['SELECT 1'],
     selectall_arrayref  => ['SELECT 1'],
     selectall_hashref   => ['SELECT 1', '1'],
     selectcol_arrayref  => ['SELECT 1'],

--- a/t/99_bug_server_prepare_blob_null.t
+++ b/t/99_bug_server_prepare_blob_null.t
@@ -12,7 +12,7 @@ $test_dsn .= ';mariadb_server_prepare=1;mariadb_server_prepare_disable_fallback=
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 
-plan tests => 11;
+plan tests => 9;
 
 ok $dbh->do("DROP TABLE IF EXISTS dbd_mysql_t99_prepare");
 
@@ -31,8 +31,6 @@ ok $sth->execute;
 my $row = $sth->fetch;
 is $row->[0] => undef;
 
-ok $sth->finish;
-
 $dbh->do("insert into dbd_mysql_t99_prepare (data) values('a')");
 $sth = $dbh->prepare("select data from dbd_mysql_t99_prepare");
 ok $sth->execute;
@@ -40,8 +38,6 @@ $row = $sth->fetch;
 is $row->[0] => undef;
 $row = $sth->fetch;
 is $row->[0] => 'a';
-
-ok $sth->finish;
 
 ok $dbh->do("DROP TABLE dbd_mysql_t99_prepare");
 

--- a/t/rt25389-bin-case.t
+++ b/t/rt25389-bin-case.t
@@ -41,7 +41,6 @@ for my $charset (qw(latin1 utf8)) {
             $i++;
         }
         is( $i, scalar @test, $q1 );
-        $sth->finish;
 
         my $q2 = "select name from `$table` where "
           . join( " OR ", map { "name = '$_'" } @test );

--- a/t/rt85919-fetch-lost-connection.t
+++ b/t/rt85919-fetch-lost-connection.t
@@ -20,7 +20,6 @@ my $ok = eval {
         ok( $sth->execute(), 'execute SQL');
         my @res = $sth->fetchrow_array();
         is ( $res[0], undef, 'no rows returned');
-        ok( $sth->finish(), 'finish');
         $sth = undef;
     }
     else {

--- a/t/rt88006-bit-prepare.t
+++ b/t/rt88006-bit-prepare.t
@@ -49,28 +49,24 @@ ok $sth = $dbh->prepare("INSERT INTO dbd_mysql_rt88006_bit_prep (id, flags) VALU
 ok $sth->bind_param(1, 4, DBI::SQL_INTEGER);
 ok $sth->bind_param(2, pack("B*", '1110000000000000011101100000000011111101'), DBI::SQL_BINARY);
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
-ok $sth->finish;
 
 ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 1");
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
 ok (my $r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario");
 is ($r->{id}, 1, 'id test contents');
 is (unpack("B*", $r->{flags}), '0000000000000000000000000000000000000010', 'flags has contents');
-ok $sth->finish;
 
 ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 3");
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
 ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with more then 32 bits");
 is ($r->{id}, 3, 'id test contents');
 is (unpack("B*", $r->{flags}), '1111011111101111101101111111101111111101', 'flags has contents');
-ok $sth->finish;
 
 ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 4");
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
 ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with binary insert");
 is ($r->{id}, 4, 'id test contents');
 is (unpack("B*", $r->{flags}), '1110000000000000011101100000000011111101', 'flags has contents');
-ok $sth->finish;
 
 ok $sth = $dbh->prepare("SELECT id,BIN(flags) FROM dbd_mysql_rt88006_bit_prep WHERE ID =1");
 ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
@@ -90,7 +86,6 @@ ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with BIN() an
 is ($r->{id}, 4, 'id test contents');
 is ($r->{'BIN(flags)'}, '1110000000000000011101100000000011111101', 'flags has contents');
 
-ok $sth->finish;
 ok $dbh->disconnect;
 }
 


### PR DESCRIPTION
Set $sth->{Active} attribute to off after fetching all data and do not call $sth->finish() method after fetching all data. Also fix other problems related to fetching data and $sth->{Active} attribute.

This should fix problem that DBI thrown following warning:
```
DBI::db=HASH(...)->disconnect invalidates 1 active statement handle (either destroy statement handles or call finish on them before disconnecting)
```

Fixes: https://github.com/jhthorsen/mojo-mysql/pull/47#issuecomment-448095164
Fixes: ea8685409ac67f4c3fe235f38b53c39fcfd68e0c