### PR TITLE
Fix return value of $sth->rows when error occurred

### DIFF
--- a/MariaDB.xs
+++ b/MariaDB.xs
@@ -236,6 +236,8 @@ rows(sth)
             XSRETURN_UNDEF;
         }
     }
+    if (imp_sth->row_num == (my_ulonglong)-1)
+        XSRETURN_IV(-1);
     RETVAL = my_ulonglong2sv(imp_sth->row_num);
   OUTPUT:
     RETVAL

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3777,7 +3777,7 @@ mariadb_st_prepare_sv(
   imp_sth->done_desc = FALSE;
   imp_sth->result = NULL;
   imp_sth->currow = 0;
-  imp_sth->row_num = 0;
+  imp_sth->row_num = (my_ulonglong)-1;
 
   if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
     PerlIO_printf(DBIc_LOGPIO(imp_xxh),
@@ -4139,7 +4139,7 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
 
   imp_sth->done_desc = FALSE;
   imp_sth->currow = 0;
-  imp_sth->row_num = 0;
+  imp_sth->row_num = (my_ulonglong)-1;
 
   /* clear NUM_OF_FIELDS attribute */
   DBIc_DBISTATE(imp_sth)->set_attr_k(sth, sv_2mortal(newSVpvs("NUM_OF_FIELDS")), 0, sv_2mortal(newSViv(0)));

--- a/t/35prepare.t
+++ b/t/35prepare.t
@@ -64,7 +64,7 @@ for (my $i = 0 ; $i < 10; $i++)
    # save these values for later testing
   $testInsertVals->{$i}= $random_chars;
   ok($rows= $sth->execute($i, $random_chars), "Testing insert row");
-  ok($rows= 1, "Should have inserted one row");
+  is($rows, 1, "Should have inserted one row");
 }
 
 ok($sth= $dbh->prepare("SELECT * FROM dbd_mysql_t35prepare WHERE id = ? OR id = ?"),


### PR DESCRIPTION
Method $sth->rows should return -1 when number of rows is unknown or when
some error occurred. Before this change method $sth->rows returned
18446744073709551615 (2^64-1) or 0. Now -1.

Fixes: https://github.com/jhthorsen/mojo-mysql/pull/47#issuecomment-460202982
Fixes: aed157b4c56ee12cd40b23d2c9a3f514cca4d455