### PR TITLE
Fix fetching rows after calling $sth->execute() second time

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4594,6 +4594,8 @@ IV mariadb_st_execute_iv(SV* sth, imp_sth_t* imp_sth)
   if (!mariadb_st_free_result_sets(sth, imp_sth, TRUE))
     return -2;
 
+  imp_sth->currow = 0;
+
   if (use_server_side_prepare)
   {
     if (imp_sth->use_mysql_use_result)


### PR DESCRIPTION
Function mariadb_st_execute_iv() did not reset current row, so next
mariadb_st_fetch() function call returned nothing if previously all data
were already fetched.

Now execute() reset current row to first one so fetch function starts
fetching from beginning.

This fixes usage of $dbh->prepare_cached() method, specially in
construction like this: $dbh->selectcol_arrayref($dbh->prepare_cached(...))

Fixes: 4f47a063f6c9fd89d709508022092965c29716df