### PR TITLE
Skip tests in the END block explicitely

### DIFF
--- a/t/14destruct.t
+++ b/t/14destruct.t
@@ -21,5 +21,5 @@ $SIG{__WARN__} = sub { die @_ };
 END {
     my $sth1_copy = $sth1;
     my $sth2_copy = $sth2;
-    pass;
+    pass if $sth1;
 }


### PR DESCRIPTION
skip_all doesn't skip assertions in the END block.