### PR TITLE
Skip double socket close prevention for Windows UCRT builds

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3213,7 +3213,16 @@ static void mariadb_db_close_mysql(pTHX_ imp_drh_t *imp_drh, imp_dbh_t *imp_dbh)
     */
     if (imp_dbh->sock_fd >= 0)
     {
+#ifdef _UCRT
+    /*
+      Disassociation is not possible for UCRT builds as UCRT does not provide
+      access to native Windows handle. Skipping disassociation introduce race
+      condition, double close, possible closing of recycled handle and crashes.
+     */
+    #warning DBD::MariaDB compiled with UCRT runtime may crash
+#else
     _set_osfhnd(imp_dbh->sock_fd, INVALID_HANDLE_VALUE);
+#endif
     close(imp_dbh->sock_fd);
     }
 #endif

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -114,6 +114,8 @@
 
 /* _set_osfhnd() is copied from Perl source file win32.h */
 #ifdef _WIN32
+/* __pioinfo[] is exported only for msvcrt builds, not for UCRT builds */
+#ifndef _UCRT
 typedef intptr_t ioinfo;
 extern __declspec(dllimport) ioinfo* __pioinfo[];
 #  define IOINFO_L2E 5
@@ -126,6 +128,7 @@ extern __declspec(dllimport) ioinfo* __pioinfo[];
    )
 #  define _osfhnd(i) (*(_pioinfo(i)))
 #  define _set_osfhnd(fh, osfh) (void)(_osfhnd(fh) = (intptr_t)osfh)
+#endif
 #endif
 
 /* PERL_UNUSED_ARG does not exist prior to perl 5.9.3 */


### PR DESCRIPTION
New Windows UCRT library which implements C Runtime and is replacement for old MSVCRT library does not export __pioinfo[] array and so does not provide a way to replace native Windows handle associated with file descriptor. As the __pioinfo[] array symbol is not available, compilation of DBD-MariaDB is causing linker errors when building with Perl compiled against UCRT (as opposite of the MSVCRT).

Skip the double socket close prevention for Windows UCRT builds as it is not possible to compile this code.

Fixes: https://github.com/perl5-dbi/DBD-MariaDB/issues/231